### PR TITLE
Protect file case when globalizing the oid in dropbox

### DIFF
--- a/cloudsync/providers/dropbox.py
+++ b/cloudsync/providers/dropbox.py
@@ -681,7 +681,7 @@ class DropboxProvider(Provider):
             return None
 
         sfid = None
-        path = res.path_lower
+        path = res.path_display
         share = res.sharing_info
         if not share:
             if isinstance(res, files.FolderMetadata):

--- a/cloudsync/runnable.py
+++ b/cloudsync/runnable.py
@@ -145,7 +145,6 @@ class Runnable(ABC):
         """
         Sets a "nothing happened" flag.   This will cause backoff to remain the same, even on success.
         """
-        # log.debug("%s: set nothing happend %s", self.service_name, self.in_backoff)
         self.__clear_on_success = False
 
     def wake(self):

--- a/cloudsync/runnable.py
+++ b/cloudsync/runnable.py
@@ -145,7 +145,7 @@ class Runnable(ABC):
         """
         Sets a "nothing happened" flag.   This will cause backoff to remain the same, even on success.
         """
-        log.debug("%s: set nothing happend %s", self.service_name, self.in_backoff)
+        # log.debug("%s: set nothing happend %s", self.service_name, self.in_backoff)
         self.__clear_on_success = False
 
     def wake(self):

--- a/cloudsync/tests/test_provider.py
+++ b/cloudsync/tests/test_provider.py
@@ -2344,34 +2344,34 @@ def test_broken_upload(very_scoped_provider, content_len, operation):
 
 
 def test_globalize(provider):
-    # top path
-    info = provider.info_path("/")
-    gid = provider.globalize_oid(info.oid)
-    oid = provider.localize_oid(gid)
-    assert info.oid == oid
-
     # subpath
-    suboid = provider.mkdir("/Sub")
-    gid = provider.globalize_oid(suboid)
-    subinfo = provider.info_oid(suboid)
-    # this test is NOT effective in reproducing the known bad behavior, test needs to be enhanced to reproduce the problem
-    assert subinfo.path == "/Sub"  # double check the name and case haven't changed when globalizing
+    sub_oid = provider.mkdir("/Sub")
+    sub_gid = provider.globalize_oid(sub_oid)
+    sub_info = provider.info_oid(sub_oid)
+    assert sub_info.path == "/Sub"  # double check the name and case haven't changed when globalizing
 
-    oid = provider.localize_oid(gid)
-    assert suboid == oid
+    sub_local_oid = provider.localize_oid(sub_gid)
+    assert sub_oid == sub_local_oid
 
-    if gid == oid:
+    # top path (do the subpath first, in order to test the sharing related code paths for case preservation)
+    top_info = provider.info_path("/")
+    top_gid = provider.globalize_oid(top_info.oid)
+    top_oid = provider.localize_oid(top_gid)
+    assert top_info.oid == top_oid
+
+
+    if sub_gid == sub_local_oid:
         pytest.skip("Provider oid == gid, skipping globalize/localize tests")
 
     # localize deleted
-    provider.delete(suboid)
-    not_oid = provider.localize_oid(gid)
+    provider.delete(sub_oid)
+    not_oid = provider.localize_oid(sub_gid)
     assert not_oid is None
 
     # globalize deleted
-    gid = provider.globalize_oid(suboid)
+    gid = provider.globalize_oid(sub_oid)
     assert gid is None
 
     # wrong value
     with pytest.raises(ValueError):
-        oid = provider.localize_oid(oid)
+        oid = provider.localize_oid(sub_oid)

--- a/cloudsync/tests/test_provider.py
+++ b/cloudsync/tests/test_provider.py
@@ -2343,7 +2343,15 @@ def test_broken_upload(very_scoped_provider, content_len, operation):
         ), "File existed in the cloud, but had incorrect size"
 
 
-def test_globalize(provider):
+def test_globalize_root(provider):
+    # top path (do the subpath first, in order to test the sharing related code paths for case preservation)
+    top_info = provider.info_path("/")
+    top_gid = provider.globalize_oid(top_info.oid)
+    top_oid = provider.localize_oid(top_gid)
+    assert top_info.oid == top_oid
+
+
+def test_globalize_subfolder(provider):
     # subpath
     sub_oid = provider.mkdir("/Sub")
     sub_gid = provider.globalize_oid(sub_oid)
@@ -2353,11 +2361,6 @@ def test_globalize(provider):
     sub_local_oid = provider.localize_oid(sub_gid)
     assert sub_oid == sub_local_oid
 
-    # top path (do the subpath first, in order to test the sharing related code paths for case preservation)
-    top_info = provider.info_path("/")
-    top_gid = provider.globalize_oid(top_info.oid)
-    top_oid = provider.localize_oid(top_gid)
-    assert top_info.oid == top_oid
 
 
     if sub_gid == sub_local_oid:

--- a/cloudsync/tests/test_provider.py
+++ b/cloudsync/tests/test_provider.py
@@ -2351,8 +2351,12 @@ def test_globalize(provider):
     assert info.oid == oid
 
     # subpath
-    suboid = provider.mkdir("/sub")
+    suboid = provider.mkdir("/Sub")
     gid = provider.globalize_oid(suboid)
+    subinfo = provider.info_oid(suboid)
+    # this test is NOT effective in reproducing the known bad behavior, test needs to be enhanced to reproduce the problem
+    assert subinfo.path == "/Sub"  # double check the name and case haven't changed when globalizing
+
     oid = provider.localize_oid(gid)
     assert suboid == oid
 


### PR DESCRIPTION
fixes https://vidaid.atlassian.net/browse/BI2-1413