### PR TITLE
assert if requests is used incorrectly

### DIFF
--- a/cloudsync/oauth/oauth_config.py
+++ b/cloudsync/oauth/oauth_config.py
@@ -139,6 +139,7 @@ class OAuthConfig:
             self._session = OAuth2Session(client_id=self.app_id, scope=scope, redirect_uri=self.redirect_uri)
         extra["client_id"] = self.app_id
         extra["client_secret"] = self.app_secret
+        extra["timeout"] = 60
         if isinstance(token, OAuthToken):
             token = token.refresh_token
         self._token = OAuthToken(self._session.refresh_token(refresh_url, refresh_token=token, **extra))

--- a/cloudsync/providers/box.py
+++ b/cloudsync/providers/box.py
@@ -266,7 +266,7 @@ class BoxProvider(Provider):  # pylint: disable=too-many-instance-attributes, to
                 headers = {'Authorization': 'Bearer %s' % (self.__access_token,)}
                 log.debug("headers: %s", headers)
                 srv_resp: requests.Response = self.__long_poll_session.options(self._base_box_url + self._events_endpoint,
-                                                                               headers=headers)
+                                                                               headers=headers, timeout=timeout)
                 log.debug("response content is %s, %s", srv_resp.status_code, srv_resp.content)
                 if not 200 <= srv_resp.status_code < 300:
                     raise CloudTokenError(srv_resp)

--- a/cloudsync/tests/test_provider.py
+++ b/cloudsync/tests/test_provider.py
@@ -27,6 +27,7 @@ import time
 from typing import Optional, Generator, TYPE_CHECKING, List, cast
 from unittest.mock import patch
 
+import requests
 import msgpack
 import pytest
 from _pytest.fixtures import FixtureLookupError
@@ -103,6 +104,21 @@ class ProviderTextMixin(ProviderBase):
         self.prov._api = lambda *ar, **kw: self.__api_retry(self._api, *ar, **kw)
 
         prov.test_short_poll_only(short_poll_only=short_poll_only)
+
+        self.__patches = []
+
+        # ensure requests lib is used correctly
+        old_request = requests.Session.request
+
+        def new_request(*request_args, **request_kwargs):
+            if not request_kwargs.get("timeout", None):
+                log.error("request called without timout")
+                assert False
+            return old_request(*request_args, **request_kwargs)
+
+        p = patch.object(requests.Session, "request", new_request)
+        p.start()
+        self.__patches.append(p)
 
         if connect:
             try:
@@ -308,7 +324,13 @@ class ProviderTextMixin(ProviderBase):
         except Exception as e:
             log.error("error during cleanup %s", repr(e))
 
-    def test_cleanup(self):
+    def test_cleanup(self, *, connected):
+        for p in self.__patches:
+            p.stop()
+
+        if not connected:
+            return
+
         if not self.prov.connected:
             self.prov.connect(self._test_creds)
         info = self.prov.info_path(self.test_root)
@@ -376,9 +398,8 @@ def mixin_provider(prov, connect=True, short_poll_only=True):
     else:
         yield providers
 
-    if connect:
-        for curr_prov in providers:
-            curr_prov.test_cleanup()
+    for curr_prov in providers:
+        curr_prov.test_cleanup(connected=connect)
 
 
 @pytest.fixture
@@ -1659,6 +1680,8 @@ def test_listdir(provider):
     provider.create(outer + "/file2", BytesIO(b"there"))
     provider.create(inner + "/file3", BytesIO(b"world"))
     contents = list(provider.listdir(outer_oid))
+    assert all([x.oid for x in contents])
+    assert all([x.otype for x in contents])
     names = [x.name for x in contents]
     assert len(names) == 3
     expected = ["file1", "file2", temp_name[1:]]
@@ -2110,7 +2133,7 @@ def test_specific_test_root():
     # and i created it
     assert base.info_path(provider.test_root).otype == cloudsync.DIRECTORY 
 
-    provider.test_cleanup()
+    provider.test_cleanup(connected=True)
 
     # and i dont delete the test root
     assert list(base.listdir_path("/banana")) == []

--- a/cloudsync/tests/test_provider.py
+++ b/cloudsync/tests/test_provider.py
@@ -112,7 +112,7 @@ class ProviderTextMixin(ProviderBase):
 
         def new_send(*args, **kwargs):
             if not kwargs.get("timeout", None):
-                log.error("called without timout")
+                log.error("requests called without timout", stack_info=True)
                 assert False
             return old_send(*args, **kwargs)
 

--- a/cloudsync/tests/test_provider.py
+++ b/cloudsync/tests/test_provider.py
@@ -108,15 +108,15 @@ class ProviderTextMixin(ProviderBase):
         self.__patches = []
 
         # ensure requests lib is used correctly
-        old_request = requests.Session.request
+        old_send = requests.Session.send
 
-        def new_request(*request_args, **request_kwargs):
-            if not request_kwargs.get("timeout", None):
-                log.error("request called without timout")
+        def new_send(*args, **kwargs):
+            if not kwargs.get("timeout", None):
+                log.error("called without timout")
                 assert False
-            return old_request(*request_args, **request_kwargs)
+            return old_send(*args, **kwargs)
 
-        p = patch.object(requests.Session, "request", new_request)
+        p = patch.object(requests.Session, "send", new_send)
         p.start()
         self.__patches.append(p)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ requires-python = ">=3.6"
 
 [tool.flit.metadata.requires-extra]
 box = [ "boxsdk", ]
-dropbox = [ "dropbox", ]
+dropbox = [ "dropbox", "six>=1.14.0"]
 boxcom = [ "boxsdk[jwt]", ]
 onedrive = [ "cloudsync-onedrive", ]
 gdrive = [ "cloudsync-gdrive", ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ google-api-python-client
 
 # dropbox provider
 dropbox
+six>=1.14.0
 
 # box provider
 boxsdk[jwt]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,8 +12,8 @@ google-auth-httplib2
 google-api-python-client
 
 # dropbox provider
-dropbox
-six>=1.14.0
+dropbox>=10.1.1
+six>=1.12.0
 
 # box provider
 boxsdk[jwt]


### PR DESCRIPTION
this causes a traceback and failure when requests libs are used without timeouts.   all providers should be brought up to date for this to be merged.