### PR TITLE
Fix out of order events

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,10 +1,16 @@
             GNU LESSER GENERAL PUBLIC LICENSE
 
 'cloudsync' is Copyright (C) 2019 Atakama, LLC
-Contact: http://www.atakama.com/
 
-You may use, distribute and copy 'cloudsync' under the terms of
-GNU Lesser General Public License version 3, which is displayed below.
+For commercial licensing and support, please contact: info@atakama.com
+
+Atakama LLC is distributing this library in the hope that it will be useful, 
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+
+See the GNU Lesser General Public License version 3 (below) for more 
+details and the limitations around any commercial use of the files distributed 
+with this library.
 
 -------------------------------------------------------------------------
 

--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -463,7 +463,8 @@ class SyncManager(Runnable):
         for ent in conflicts:
             info = self.providers[synced].info_oid(ent[synced].oid)
             if not info:
-                ent[synced].exists = MISSING
+                if ent[synced].exists != TRASHED:
+                    ent[synced].exists = MISSING
             else:
                 nc.append(ent)
 
@@ -707,7 +708,7 @@ class SyncManager(Runnable):
                             parent_ent[changed].changed = True
                             parent_ent[synced].exists = MISSING
                             assert parent_ent.is_creation(changed), "%s is not a creation" % parent_ent
-                            log.debug("updated entry %s", parent)
+                            log.debug("updated entry as missing %s", parent)
         except ex.CloudFileExistsError:
             # there's a file or folder in the way, let that resolve if possible
             log.debug("can't create %s, try punting", translated_path)
@@ -1395,6 +1396,7 @@ class SyncManager(Runnable):
 
         info = self.providers[changed].info_oid(sync[changed].oid)
         if not info:
+            log.debug("marking missing %s", debug_sig(sync[changed].oid))
             sync[changed].exists = MISSING
             return
 

--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -557,6 +557,9 @@ class SyncManager(Runnable):
 
         try:
             return self.unsafe_mkdir_synced(changed, synced, sync, translated_path)
+        except ex.CloudFileExistsError:
+            sync.probably_changed(synced)
+
         except ex.CloudFileNotFoundError:
             if sync.priority <= 0:
                 return PUNT

--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -558,7 +558,7 @@ class SyncManager(Runnable):
         try:
             return self.unsafe_mkdir_synced(changed, synced, sync, translated_path)
         except ex.CloudFileExistsError:
-            sync.probably_changed(synced)
+            sync.mark_dirty(synced)
 
         except ex.CloudFileNotFoundError:
             if sync.priority <= 0:

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -557,7 +557,7 @@ class SyncEntry:
                 self._parent.unconditionally_get_latest(self, side)
                 self[side]._last_gotten = max_changed
 
-    def probably_changed(self, side):
+    def mark_dirty(self, side):
         self[side]._last_gotten = 0
 
     def is_latest(self) -> bool:

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -557,6 +557,9 @@ class SyncEntry:
                 self._parent.unconditionally_get_latest(self, side)
                 self[side]._last_gotten = max_changed
 
+    def probably_changed(self, side):
+        self[side]._last_gotten = 0
+
     def is_latest(self) -> bool:
         max_changed = max(self[LOCAL].changed or 0, self[REMOTE].changed or 0)
         for side in (LOCAL, REMOTE):

--- a/cloudsync/tests/test_sync.py
+++ b/cloudsync/tests/test_sync.py
@@ -1201,4 +1201,32 @@ def test_rename_same_name(sync_ci):
     log.info("TABLE 2\n%s", sync.state.pretty_print())
 
 
+def test_delete_out_of_order_events(sync):
+    (local, remote) = sync.providers
+
+    (
+        (lf, rf),
+        (la, ra),
+        (lb, rb),
+    ) = setup_remote_local(sync, "f/", "f/a", "f/b")
+
+    local.delete(la.oid)
+    local.delete(lb.oid)
+    local.delete(lf.oid)
+
+    sync.create_event(LOCAL, FILE, path="/local/f/a", oid=la.oid, exists=False)
+    sync.create_event(LOCAL, FILE, path="/local/f/b", oid=lb.oid, exists=False)
+    sync.create_event(LOCAL, FILE, path="/local/f/b", oid=lb.oid, exists=True)  # liar!
+    sync.create_event(LOCAL, FILE, path="/local/f", oid=lf.oid, exists=False)
+
+    log.info("TABLE 0\n%s", sync.state.pretty_print())
+
+    sync.run_until_clean()
+
+    log.info("TABLE 2\n%s", sync.state.pretty_print())
+
+    assert not remote.info_path("/remote/f")
+
+
+
 # TODO: test to confirm that a sync with an updated path name that is different but matches the old name will be ignored (eg: a/b -> a\b)


### PR DESCRIPTION
For oid-as-path providers, we rely on event ordering to determine whether something is a legitimate "trashed" event (actionable) or just a file that's "missing".  This helps resolve event ordering problems when files are removed and created near the same time.

Since we had a situation where an oid_is_path provider caused out-of-order events, this fixes the case where an out-of-order event can cause sync problems.

Notably, however, we are not deferring to "create" in the case where a file is missing.   

While testing this, I found a bug where mkdir on a folder which conflicts a file doesn't properly handle the FileExistsError by marking the sync entry to be "gotten latest" again.
 