### PR TITLE
fix handling of missing file during sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-PYTEST = pytest -rfE --cov=cloudsync --durations=1 -n=8 cloudsync/tests --tb=short --timeout=10
+PYTEST = pytest -rfE --cov=cloudsync --durations=1 -n=8 cloudsync/tests --tb=short --timeout=20
 
 ifeq ($(OS),Windows_NT)
 	ENVBIN="scripts"

--- a/cloudsync/providers/box.py
+++ b/cloudsync/providers/box.py
@@ -13,7 +13,7 @@ from boxsdk.object.item import Item as BoxItem
 from boxsdk.object.folder import Folder as BoxFolder
 from boxsdk.object.file import File as BoxFile
 from boxsdk.object.event import Event as BoxEvent
-from boxsdk.exception import BoxAPIException, BoxNetworkException, BoxOAuthException
+from boxsdk.exception import BoxAPIException, BoxNetworkException, BoxOAuthException, BoxValueError
 from boxsdk.session.session import Session, AuthorizedSession
 
 from cloudsync.hierarchical_cache import HierarchicalCache
@@ -217,6 +217,8 @@ class BoxProvider(Provider):  # pylint: disable=too-many-instance-attributes, to
                 except BoxNetworkException as e:
                     self.__box.disconenct()
                     raise CloudDisconnectedError("disconnected %s" % e)
+                except BoxValueError:
+                    raise CloudFileNotFoundError()
                 except BoxAPIException as e:
                     if e.status == 400 and e.code == 'folder_not_empty':
                         raise CloudFileExistsError()

--- a/cloudsync/providers/filesystem.py
+++ b/cloudsync/providers/filesystem.py
@@ -647,11 +647,15 @@ class FileSystemProvider(Provider):                     # pylint: disable=too-ma
         with self._api():
             path = self._oid_to_fpath(oid)
             if os.path.isdir(path):
+                log.debug("delete dir %s", path)
                 if self._folder_oid_has_contents(oid):
                     raise ex.CloudFileExistsError("Cannot delete non-empty folder %s:%s" % (oid, path))
                 os.rmdir(path)
             elif os.path.exists(path):
+                log.debug("delete file %s", path)
                 os.unlink(path)
+            else:
+                log.debug("delete ??? %s", path)
 
     def exists_oid(self, oid):
         with self._api():

--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -1394,8 +1394,7 @@ class SyncManager(Runnable):
     def handle_changed_is_missing(self, sync, changed, synced):     # pylint: disable=no-self-use
         if (sync[synced].exists == EXISTS and sync.paths_match(changed) and
             sync[changed].hash == sync[changed].sync_hash):
-            #TODO: and not sync[synced].changed -- another condition that was in Mike's original change
-            if sync.priority <= 2:
+            if sync.priority <= 5:
                 log.warning("%s missing, other side exists. punting: %s", sync[changed].path, sync)
                 return PUNT
             # The synced side thinks it's synced, but it isn't -- the file is missing on the changed side

--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -1394,7 +1394,7 @@ class SyncManager(Runnable):
     def handle_changed_is_missing(self, sync, changed, synced):     # pylint: disable=no-self-use
         if (sync[synced].exists == EXISTS and sync.paths_match(changed) and
             sync[changed].hash == sync[changed].sync_hash):
-            if sync.priority <= 5:
+            if sync.priority <= 4:
                 log.warning("%s missing, other side exists. punting: %s", sync[changed].path, sync)
                 return PUNT
             # The synced side thinks it's synced, but it isn't -- the file is missing on the changed side

--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -1392,8 +1392,9 @@ class SyncManager(Runnable):
         return FINISHED
 
     def handle_changed_is_missing(self, sync, changed, synced):     # pylint: disable=no-self-use
-        if (sync[synced].exists == EXISTS and sync.paths_match(changed) and
-            sync[changed].hash == sync[changed].sync_hash):
+        log.debug("%s missing", sync[changed].path)
+
+        if sync[synced].exists == EXISTS:
             if sync.priority <= 4:
                 log.warning("%s missing, other side exists. punting: %s", sync[changed].path, sync)
                 return PUNT
@@ -1406,7 +1407,7 @@ class SyncManager(Runnable):
             sync[synced].sync_hash = None
             sync[synced].changed = time.time()
             log.warning("%s now unsynced: %s", sync[synced].path, sync)
-        log.debug("%s missing", sync[changed].path)
+
         return FINISHED
 
     def handle_hash_diff(self, sync, changed, synced):

--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -1339,6 +1339,10 @@ class SyncManager(Runnable):
             return self.delete_synced(sync, changed, synced)
 
         if sync[changed].exists == MISSING:
+            if sync[synced].exists == EXISTS and not sync[synced].changed:
+                sync[synced].changed = time.time()
+                log.warning("%s missing, other side exists. Marking other side changed.")
+                # do we want to punt here, or fall through to marking finished?
             log.debug("%s missing", sync[changed].path)
             return FINISHED
 

--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -1397,7 +1397,7 @@ class SyncManager(Runnable):
     def handle_changed_is_missing(self, sync, changed, synced):     # pylint: disable=no-self-use
         if (sync[synced].exists == EXISTS and sync.paths_match(changed) and
             sync[changed].hash == sync[changed].sync_hash):
-            #not sync[synced].changed and #TODO: was in Mike's original change
+            #TODO: and not sync[synced].changed -- another condition that was in Mike's original change
             if sync.priority <= 2:
                 log.warning("%s missing, other side exists. punting: %s", sync[changed].path, sync)
                 return PUNT

--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -339,8 +339,7 @@ class SyncManager(Runnable):
         something_got_done = False
 
         for side in ordered:
-            missing_not_finished = sync[side].exists == MISSING and sync[other_side(side)].exists == EXISTS
-            if not sync[side].needs_sync() and not missing_not_finished:
+            if not sync[side].needs_sync() and not sync.side_missing_other_exists(side):
                 if sync[side].changed:
                     log.log(TRACE, "Sync entry marked as changed, but doesn't need sync, finishing. %s", sync)
                 sync[side].changed = 0

--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -1395,12 +1395,10 @@ class SyncManager(Runnable):
         log.debug("nothing changed %s", sync)
         return FINISHED
 
-    def handle_changed_is_missing(self, sync, changed, synced):
-        if (sync[synced].exists == EXISTS and
+    def handle_changed_is_missing(self, sync, changed, synced):     # pylint: disable=no-self-use
+        if (sync[synced].exists == EXISTS and sync.paths_match(changed) and
+            sync[changed].hash == sync[changed].sync_hash):
             #not sync[synced].changed and #TODO: was in Mike's original change
-            self.providers[changed].paths_match(sync[changed].path, sync[changed].sync_path, for_display=True) and
-            sync[changed].hash == sync[changed].sync_hash
-        ):
             if sync.priority <= 2:
                 log.warning("%s missing, other side exists. punting: %s", sync[changed].path, sync)
                 return PUNT
@@ -1413,10 +1411,8 @@ class SyncManager(Runnable):
             sync[synced].sync_hash = None
             sync[synced].changed = time.time()
             log.warning("%s now unsynced: %s", sync[synced].path, sync)
-            # raise BaseException("Got here")
         log.debug("%s missing", sync[changed].path)
         return FINISHED
-
 
     def handle_hash_diff(self, sync, changed, synced):
         if sync[changed].path is None:

--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -1007,9 +1007,6 @@ class SyncManager(Runnable):
                     all_synced = False
                     break
             if all_synced:
-                # from https://github.com/AtakamaLLC/cloudsync/pull/256/files
-                # This is bad, because we don't even check the file system to ensure that we are actually synced,
-                # we're depending on the state table, but needs_sync() doesn't cover every possibility?
                 log.info("Attempt dropping dir removal because children appear fully synced %s", sync[changed].path)
                 remaining = []
                 # Potentially missing ents in state table

--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -1379,9 +1379,9 @@ class SyncManager(Runnable):
 
         if sync[changed].exists == MISSING:
             if (sync[synced].exists == EXISTS and
-                    not sync[synced].changed and
-                    sync[changed].path == sync[changed].sync_path
-                    and sync[changed].hash == sync[changed].sync_hash
+                    #not sync[synced].changed and #TODO: was in Mike's original change
+                    self.providers[changed].paths_match(sync[changed].path, sync[changed].sync_path, for_display=True) and
+                    sync[changed].hash == sync[changed].sync_hash
             ):
                 if sync.priority <= 2:
                     log.warning("%s missing, other side exists. punting: %s", sync[changed].path, sync)

--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -339,9 +339,9 @@ class SyncManager(Runnable):
         something_got_done = False
 
         for side in ordered:
-            if not sync[side].needs_sync() and not sync.side_missing_other_exists(side):
+            if not sync[side].needs_sync():
                 if sync[side].changed:
-                    log.log(TRACE, "Sync entry marked as changed, but doesn't need sync, finishing. %s", sync)
+                    log.debug("Sync entry marked as changed, but doesn't need sync, finishing. %s", sync)
                 sync[side].changed = 0
                 continue
 
@@ -714,9 +714,6 @@ class SyncManager(Runnable):
             return FINISHED
 
         # parent presumably exists
-        # why are we using the changed side path without translating it to local?
-        # why are we marking the folder as changed on the changed side?
-        # This won't do anything if we don't change the sync path or sync hash, btw...
         parent = self.providers[changed].dirname(sync[changed].path)
         log.debug("sync %s first before %s", parent, sync[changed].path)
         ents = self.state.lookup_path(changed, parent)

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -141,7 +141,8 @@ class SideState():
         return self.changed and self.oid and (
                self.hash != self.sync_hash or
                self.path != self.sync_path or
-               self.exists in (TRASHED, LIKELY_TRASHED))
+               self.exists in (TRASHED, LIKELY_TRASHED)  # do we want to add MISSING here?
+        )
 
     def clean_temp(self):
         if self.temp_file:

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -582,9 +582,6 @@ class SyncEntry:
                     return True
         return False
 
-    def side_missing_other_exists(self, side):
-        return self[side].exists == MISSING and self[other_side(side)].exists == EXISTS
-
 
 @strict
 class SyncState:  # pylint: disable=too-many-instance-attributes, too-many-public-methods

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -1225,6 +1225,8 @@ class SyncState:  # pylint: disable=too-many-instance-attributes, too-many-publi
         if ent[i].exists != TRASHED:
             # we haven't gotten a trashed event yet
             ent[i].exists = MISSING
+            if not self.providers[i].oid_is_path:
+                ent[i].exists = TRASHED
 
     def unconditionally_get_latest(self, ent, i):
         if ent[i].oid is None:

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -141,7 +141,7 @@ class SideState():
         return self.changed and self.oid and (
                self.hash != self.sync_hash or
                self.parent.paths_differ(self.side) or
-               self.exists in (TRASHED, LIKELY_TRASHED, MISSING))  # do we want to add MISSING here?
+               self.exists in (TRASHED, LIKELY_TRASHED, MISSING))
 
     def clean_temp(self):
         if self.temp_file:
@@ -1221,9 +1221,7 @@ class SyncState:  # pylint: disable=too-many-instance-attributes, too-many-publi
 
         if ent[i].exists != TRASHED:
             # we haven't gotten a trashed event yet
-            ent[i].exists = MISSING
-            if not self.providers[i].oid_is_path:
-                ent[i].exists = TRASHED
+            ent[i].exists = MISSING if self.providers[i].oid_is_path else TRASHED
 
     def unconditionally_get_latest(self, ent, i):
         if ent[i].oid is None:

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -141,7 +141,7 @@ class SideState():
         return self.changed and self.oid and (
                self.hash != self.sync_hash or
                self.parent.paths_differ(self.side) or
-               self.exists in (TRASHED, LIKELY_TRASHED))  # do we want to add MISSING here?
+               self.exists in (TRASHED, LIKELY_TRASHED, MISSING))  # do we want to add MISSING here?
 
     def clean_temp(self):
         if self.temp_file:

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -582,6 +582,9 @@ class SyncEntry:
                     return True
         return False
 
+    def side_missing_other_exists(self, side):
+        return self[side].exists == MISSING and self[other_side(side)].exists == EXISTS
+
 
 @strict
 class SyncState:  # pylint: disable=too-many-instance-attributes, too-many-public-methods

--- a/cloudsync/tests/test_cs.py
+++ b/cloudsync/tests/test_cs.py
@@ -303,6 +303,8 @@ def test_cs_sharing_conflict_update_file_and_rename_parent_folder(four_local_cs)
             raise TimeoutError()
         return cs.state.changeset_len == 0
 
+    log.info("TABLE %s\n%s", i, cs1.state.pretty_print())
+
     try:
         for i in range(0, 4):
             four_local_cs[i].start(sleep=0.01)  # Start the sync

--- a/cloudsync/tests/test_cs.py
+++ b/cloudsync/tests/test_cs.py
@@ -232,7 +232,7 @@ def multi_local_cs_setup(css: Tuple[CloudSyncMixin], local_objects, local_parent
     counter = 1
     for cs in css:
         log.info("SETUP TABLE 1 cs%s\n%s", counter, cs.state.pretty_print())
-        cs.run_until_clean(timeout=3)
+        cs.run_until_clean(timeout=10)
         log.info("SETUP TABLE 2 cs%s\n%s", counter, cs.state.pretty_print())
         counter += 1
 
@@ -312,7 +312,7 @@ def test_cs_sharing_conflict_update_file_and_rename_parent_folder(four_local_cs)
 
         for i in range(0, 4):
             start = time.monotonic()
-            four_local_cs[i].wait_until(found=lambda: finished_condition(i, timeout=30), timeout=10)
+            four_local_cs[i].wait_until(found=lambda: finished_condition(i, timeout=30), timeout=30)
     finally:
         for i in range(0, 4):
             four_local_cs[i].stop()  # Stop the sync

--- a/cloudsync/tests/test_sync.py
+++ b/cloudsync/tests/test_sync.py
@@ -1410,13 +1410,13 @@ def test_missing_not_finished(sync):
     log.info("TABLE 3\n%s", sync.state.pretty_print())
 
     if local.oid_is_path:
-        # missing events for oid_is_path shold never happen, and if they do, we re-vivify the missing files
+        # missing events for oid_is_path should never happen, and if they do, we re-vivify the missing files
         # this is for safety
         assert local.exists_path('/local/d')
         assert local.exists_path('/local/d/a')
     else:
-        # missing events for oid_is_oid may happen (oneddrive, gdrive do this)
-        # however, the object id is unique and winn never be reused, so we know not to recreate
+        # missing events for oid_is_oid may happen (onedrive, gdrive do this)
+        # however, the object id is unique and will never be reused, so we know not to recreate
         assert not local.exists_path('/local/d')
         assert not local.exists_path('/local/d/a')
 

--- a/cloudsync/tests/test_sync.py
+++ b/cloudsync/tests/test_sync.py
@@ -3,7 +3,7 @@
 import logging
 import time
 from io import BytesIO
-from typing import List, Tuple, Union
+from typing import List
 from itertools import permutations
 
 from unittest.mock import patch, MagicMock

--- a/cloudsync/tests/test_sync.py
+++ b/cloudsync/tests/test_sync.py
@@ -1201,4 +1201,31 @@ def test_rename_same_name(sync_ci):
     log.info("TABLE 2\n%s", sync.state.pretty_print())
 
 
+def test_delete_out_of_order_events(sync):
+    (local, remote) = sync.providers
+
+    (
+        (lf, rf),
+        (la, ra),
+        (lb, rb),
+    ) = setup_remote_local(sync, "f/", "f/a", "f/b")
+
+    local.delete(la.oid)
+    local.delete(lb.oid)
+    local.delete(lf.oid)
+
+    sync.create_event(LOCAL, FILE, path="/local/f/a", oid=la.oid, exists=False)
+    sync.create_event(LOCAL, FILE, path="/local/f/b", oid=lb.oid, exists=False)
+    sync.create_event(LOCAL, FILE, path="/local/f/b", oid=lb.oid, exists=True)  # liar!
+    sync.create_event(LOCAL, FILE, path="/local/f", oid=lf.oid, exists=False)
+
+    log.info("TABLE 0\n%s", sync.state.pretty_print())
+
+    sync.run_until_clean()
+
+    log.info("TABLE 2\n%s", sync.state.pretty_print())
+
+    assert not remote.info_path("/remote/f")
+
+
 # TODO: test to confirm that a sync with an updated path name that is different but matches the old name will be ignored (eg: a/b -> a\b)


### PR DESCRIPTION
mark the other side changed if the other side exists and is unchanged, before finalizing syncing a missing file