### PR TITLE
Fix infinite sync loop in rename codepath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,6 @@ venv.bak/
 
 # PyCharm
 .idea
+
+# Visual Studio Code
+.vscode/

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -140,7 +140,7 @@ class SideState():
     def needs_sync(self):
         return self.changed and self.oid and (
                self.hash != self.sync_hash or
-               self.path != self.sync_path or
+               self.parent.paths_differ(self.side) or
                self.exists in (TRASHED, LIKELY_TRASHED))
 
     def clean_temp(self):
@@ -351,21 +351,27 @@ class SyncEntry:
         return False
 
     def is_path_change(self, changed):
-        return self[changed].sync_path is not None and self[changed].path != self[changed].sync_path
+        return self[changed].sync_path and self.paths_differ(changed)
 
     def is_creation(self, changed):
         return (not self[other_side(changed)].oid or self[other_side(changed)].exists in (TRASHED, MISSING)) \
                 and self[changed].path and self[changed].exists == EXISTS
 
     def is_rename(self, changed):
-        return (self[changed].sync_path and self[changed].path
-                and self[changed].sync_path != self[changed].path)
+        return self[changed].sync_path and self[changed].path and self.paths_differ(changed)
+
+    def paths_match(self, side):
+        prov = self.parent.providers[side]
+        return prov.paths_match(self[side].sync_path, self[side].path, for_display=True)
+
+    def paths_differ(self, side):
+        return not self.paths_match(side)
 
     def needs_sync(self):
         for i in (LOCAL, REMOTE):
             if not self[i].changed:
                 continue
-            if self[i].path != self[i].sync_path and self[i].oid:
+            if self.paths_differ(i) and self[i].oid:
                 return True
             if self[i].hash != self[i].sync_hash and self[i].oid:
                 return True

--- a/cloudsync/tests/test_sync.py
+++ b/cloudsync/tests/test_sync.py
@@ -1173,8 +1173,8 @@ def test_reprioritize_sync_trash_loop(sync):
     with patch("cloudsync.tests.fixtures.mock_provider.MockFSObject.hash", new=hash_creates_event):
         sync.run_until_clean(timeout=1) # times out if we get into the rename codepath
 
-    for entry in sync.state._changeset:
-        assert entry.is_discarded()
+    # ensure all entries are discarded
+    assert sync.state.entry_count() == 0
 
     log.info("TABLE 2:\n%s", sync.state.pretty_print())
 

--- a/cloudsync/tests/test_sync.py
+++ b/cloudsync/tests/test_sync.py
@@ -1093,6 +1093,36 @@ def test_path_conflict_deleted_remotely(sync):
     assert not sync.providers[LOCAL].info_oid(new_local_oid)
     assert not sync.providers[REMOTE].info_oid(new_remote_oid)
 
+
+def test_equivalent_path_and_sync_path_do_nothing(sync):
+    local_parent = "/local"
+    local_sub = "/local/sub"
+    local_file = "/local/sub/file"
+
+    # create local folders + file
+    sync.providers[LOCAL].mkdir(local_parent)
+    sync.providers[LOCAL].mkdir(local_sub)
+    lfil = sync.providers[LOCAL].create(local_file, BytesIO(b"hello"))
+
+    # sync local file to remote
+    sync.create_event(LOCAL, FILE, path=local_file, oid=lfil.oid, hash=lfil.hash)
+    sync.run_until_clean(timeout=1)
+    log.info("TABLE 0:\n%s", sync.state.pretty_print())
+    sync_entry = sync.state.lookup_oid(LOCAL, lfil.oid)
+
+    with patch.object(sync, "nothing_happened") as nothing_happened:
+        sync_entry[LOCAL].sync_path = "/local/sub\\file"
+        sync.create_event(LOCAL, FILE, path=local_file, oid=lfil.oid, hash=lfil.hash)
+        sync.run_until_clean(timeout=1)
+        nothing_happened.assert_called()
+
+    with patch.object(sync, "nothing_happened") as nothing_happened:
+        sync_entry[LOCAL].sync_path = "\\local\\sub/file"
+        sync.create_event(LOCAL, FILE, path=local_file, oid=lfil.oid, hash=lfil.hash)
+        sync.run_until_clean(timeout=1)
+        nothing_happened.assert_called()
+
+
 def test_contrived_sync_stuck_scenario(sync):
     local_parent = "/local"
     local_sub = "/local/sub"


### PR DESCRIPTION
Main issue: paths in state.py are not normalized, so they must be compared using provider.paths_match()

Secondary issue: though we should not get into the rename codepath when path and sync_path are equivalent (even if the strings don't match) I could not figure out why/how the timestamp of the LOCAL side is updated such that it is newer than the REMOTE timestamp every time through the loop -- this causes an infinite loop. In my contrived test I override the LOCAL provider's hash func to also throw an event, which has the same end result. However, there is no evidence that vfs_provider does this.

Ultimately I think all we need is a simple test that ensures equivalent paths are not treated as renames, instead of this contrived test.

Thoughts?
