### PR TITLE
process local delete as "something" to clear backoff

### DIFF
--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -374,8 +374,7 @@ class SyncManager(Runnable):
 
             response = self.embrace_change(sync, side, other_side(side))
             if response == FINISHED:
-                if sync[side].changed:
-                    something_got_done = True
+                something_got_done = True
                 self.finished(side, sync)
             elif response == PUNT:
                 sync.punt()


### PR DESCRIPTION
@earonesty -- you added the something/nothing checks a couple of months ago, let me know if you see any problems with this change.

on a local delete we set SyncEntry.ignore = discarded, which also sets local and remote .changed=0, which causes us to treat local deletes as "nothing happened"

https://vidaid.atlassian.net/browse/BI2-1531