### PR TITLE
VFM-7427: Fix SyncManager stop()

### DIFF
--- a/cloudsync/runnable.py
+++ b/cloudsync/runnable.py
@@ -185,8 +185,6 @@ class Runnable(ABC):
             if threading.current_thread() != self.__thread:
                 self.wait()
                 self.__thread = None
-        elif forever:
-            self.done()
 
     def done(self):
         """


### PR DESCRIPTION
During shutdown, if a temp file handle is open (download does this), an exception will be raised when the Sync Manager tries to delete the temp directory.  This leaves CryptVFS in a bad state. 

After investigation, the issue looks like that the `runnable.stop()` method calls `done` while the last `do` loop is still occurring. This is what causes the contention. This PR removes the call to `done` and leaves it to the finally block in the `do` loop. `done()` should only be called once the do loop has been stopped.