### PR TITLE
VFM-7455 Bump logging levels for sparse events

### DIFF
--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -548,7 +548,7 @@ class SyncManager(Runnable):
                 if ent[changed].otype == DIRECTORY:
                     # these we can toss, they are other folders
                     # keep the current one, since it exists for sure
-                    log.info("discard %s", ent)
+                    log.debug("discard %s", ent)
                     ent.ignore(IgnoreReason.DISCARDED)
 
         ents = [ent for ent in ents if TRASHED not in (
@@ -558,10 +558,10 @@ class SyncManager(Runnable):
 
         if ents:
             if sync.priority <= 0:
-                log.info("punt mkdir %s", translated_path)
+                log.info("punt mkdir %s", translated_path)  # pragma: no cover
                 return PUNT
 
-            log.info("rename to fix conflict %s", translated_path)
+            log.info("rename to fix conflict %s", translated_path)  # pragma: no cover
             self.rename_to_fix_conflict(sync, synced, translated_path)
 
         try:

--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -634,7 +634,7 @@ class SyncManager(Runnable):
                 info = self.providers[synced].create(translated_path, f)
             log.debug("created %s", info)
         except ex.CloudFileExistsError:
-            log.error("exists error %s", translated_path)
+            log.warning("exists error %s", translated_path)
             info = self.providers[synced].info_path(translated_path)
             if not info:
                 raise
@@ -990,7 +990,7 @@ class SyncManager(Runnable):
 
         sync[synced].exists = TRASHED
         if not sync.is_conflicted:
-            log.info("mark entry discarded %s", sync)
+            log.debug("mark entry discarded %s", sync)
             sync.ignore(IgnoreReason.DISCARDED, previous_reasons=IgnoreReason.IRRELEVANT)
         return FINISHED
 
@@ -1194,7 +1194,7 @@ class SyncManager(Runnable):
         try:
             new_oid = self.providers[synced].rename(sync[synced].oid, translated_path)
         except ex.CloudFileNotFoundError as e:
-            log.error("ERROR: can't rename for now %s: %s", sync, repr(e))
+            log.warning("ERROR: can't rename for now %s: %s", sync, repr(e))
             return self.handle_cloud_file_not_found_error(changed, sync, synced)
         except ex.CloudFileExistsError:
             log.warning("can't rename, file exists")

--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -601,7 +601,7 @@ class SyncManager(Runnable):
                 sync, synced, exists=True, oid=info.oid, path=sync[synced].sync_path)
             return True
         except FileNotFoundError:
-            log.error("FNF during upload %s:%s", sync[synced].sync_path, sync[changed].temp_file)
+            log.warning("FNF during upload %s:%s", sync[synced].sync_path, sync[changed].temp_file)
             return False
         except ex.CloudFileNotFoundError:
             info = self.providers[synced].info_oid(sync[synced].oid)

--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -79,7 +79,7 @@ class ResolveFile():
                     self.provider.download(self.info.oid, f)
                 os.rename(self.__temp_file + ".tmp", self.__temp_file)
             except Exception as e:
-                log.error("error downloading %s", e)
+                log.warning("error downloading %s", e)
                 try:
                     os.unlink(self.__temp_file)
                 except FileNotFoundError:
@@ -458,7 +458,7 @@ class SyncManager(Runnable):
             raise ex.CloudTemporaryError("download or rename exception %s" % e)
 
         except ex.CloudFileNotFoundError:
-            log.error("download from %s failed fnf, switch to not exists",
+            log.warning("download from %s failed fnf, switch to not exists",
                       self.providers[changed].name)
             sync[changed].exists = MISSING
             return False
@@ -573,7 +573,7 @@ class SyncManager(Runnable):
             if sync.priority <= 0:
                 return PUNT
 
-            log.error("mkdir %s : %s failed fnf, TODO fix mkdir code and stuff",
+            log.warning("mkdir %s : %s failed fnf, TODO fix mkdir code and stuff",
                       self.providers[synced].name, translated_path)
             raise NotImplementedError("TODO mkdir, and make state etc")
         except ex.CloudFileNameError:
@@ -1319,7 +1319,7 @@ class SyncManager(Runnable):
                     log.info(">>>Removing remnants of file moved out of cloud root")
                     sync[changed].exists = TRASHED  # This will discard the ent later
                 else:  # we don't have a new or old translated path... just irrelevant so discard
-                    log.info(">>>Not a cloud path %s, ignoring", sync[changed].path)
+                    log.log(TRACE, ">>>Not a cloud path %s, ignoring", sync[changed].path)
                     sync.ignore(IgnoreReason.IRRELEVANT)
 
         if sync.is_discarded:

--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -79,7 +79,7 @@ class ResolveFile():
                     self.provider.download(self.info.oid, f)
                 os.rename(self.__temp_file + ".tmp", self.__temp_file)
             except Exception as e:
-                log.debug("error downloading %s", e)
+                log.error("error downloading %s", e)
                 try:
                     os.unlink(self.__temp_file)
                 except FileNotFoundError:
@@ -451,14 +451,14 @@ class SyncManager(Runnable):
             os.rename(partial_temp, sync[changed].temp_file)
             return True
         except FileNotFoundError:
-            log.debug("file not found %s", sync[changed].path)
+            log.warning("file not found %s", sync[changed].path)
             sync[changed].clean_temp()
             return False
         except PermissionError as e:
             raise ex.CloudTemporaryError("download or rename exception %s" % e)
 
         except ex.CloudFileNotFoundError:
-            log.debug("download from %s failed fnf, switch to not exists",
+            log.error("download from %s failed fnf, switch to not exists",
                       self.providers[changed].name)
             sync[changed].exists = MISSING
             return False
@@ -495,7 +495,7 @@ class SyncManager(Runnable):
 
         chent: SyncEntry = self.get_folder_file_conflict(sync, translated_path, synced)
         if chent:
-            log.debug("resolve %s conflict with %s", translated_path, chent)
+            log.info("resolve %s conflict with %s", translated_path, chent)
             # pylint bugs here... no idea why
             self.resolve_conflict((sync[changed], chent[synced]))                   # pylint: disable=unsubscriptable-object
             # the defer entry may not have finished, so PUNT, just in case. If it is finished, it'll clear on the next go
@@ -548,7 +548,7 @@ class SyncManager(Runnable):
                 if ent[changed].otype == DIRECTORY:
                     # these we can toss, they are other folders
                     # keep the current one, since it exists for sure
-                    log.debug("discard %s", ent)
+                    log.info("discard %s", ent)
                     ent.ignore(IgnoreReason.DISCARDED)
 
         ents = [ent for ent in ents if TRASHED not in (
@@ -558,10 +558,10 @@ class SyncManager(Runnable):
 
         if ents:
             if sync.priority <= 0:
-                log.debug("punt mkdir")
+                log.info("punt mkdir %s", translated_path)
                 return PUNT
 
-            log.debug("rename to fix conflict %s", translated_path)
+            log.info("rename to fix conflict %s", translated_path)
             self.rename_to_fix_conflict(sync, synced, translated_path)
 
         try:
@@ -573,7 +573,7 @@ class SyncManager(Runnable):
             if sync.priority <= 0:
                 return PUNT
 
-            log.debug("mkdir %s : %s failed fnf, TODO fix mkdir code and stuff",
+            log.error("mkdir %s : %s failed fnf, TODO fix mkdir code and stuff",
                       self.providers[synced].name, translated_path)
             raise NotImplementedError("TODO mkdir, and make state etc")
         except ex.CloudFileNameError:
@@ -601,13 +601,13 @@ class SyncManager(Runnable):
                 sync, synced, exists=True, oid=info.oid, path=sync[synced].sync_path)
             return True
         except FileNotFoundError:
-            log.info("FNF during upload %s:%s", sync[synced].sync_path, sync[changed].temp_file)
+            log.error("FNF during upload %s:%s", sync[synced].sync_path, sync[changed].temp_file)
             return False
         except ex.CloudFileNotFoundError:
             info = self.providers[synced].info_oid(sync[synced].oid)
 
             if not info:
-                log.debug("convert to missing")
+                log.info("convert to missing")
                 sync[synced].exists = MISSING
             else:
                 # you got an FNF during upload, but when you queried... it existed
@@ -617,7 +617,7 @@ class SyncManager(Runnable):
             return False
         except ex.CloudFileExistsError:
             # this happens if the remote oid is a folder
-            log.debug("split bc upload to folder")
+            log.info("split bc upload to folder")
 
             defer_ent, defer_side, replace_ent, replace_side \
                 = self.state.split(sync)
@@ -634,7 +634,7 @@ class SyncManager(Runnable):
                 info = self.providers[synced].create(translated_path, f)
             log.debug("created %s", info)
         except ex.CloudFileExistsError:
-            log.debug("exists error %s", translated_path)
+            log.error("exists error %s", translated_path)
             info = self.providers[synced].info_path(translated_path)
             if not info:
                 raise
@@ -684,14 +684,14 @@ class SyncManager(Runnable):
             return self.handle_cloud_file_not_found_error(changed, sync, synced)
         except ex.CloudFileExistsError:
             # there's a file or folder in the way, let that resolve if possible
-            log.debug("can't create %s, try punting", translated_path)
+            log.info("can't create %s, try punting", translated_path)
 
             if sync.priority > 0:
                 info = self.providers[synced].info_path(translated_path)
                 if not info:
-                    log.debug("got a file exists, and then it didn't exist %s", sync)
+                    log.info("got a file exists, and then it didn't exist %s", sync)
                     if sync.priority > 1:
-                        log.debug("repeated errors here, converting to pathname error %s", sync)
+                        log.warning("repeated errors here, converting to pathname error %s", sync)
                         self.handle_file_name_error(sync, synced, translated_path)
                         return FINISHED
                 else:
@@ -715,7 +715,7 @@ class SyncManager(Runnable):
 
         # parent presumably exists
         parent = self.providers[changed].dirname(sync[changed].path)
-        log.debug("sync %s first before %s", parent, sync[changed].path)
+        log.info("CloudFileNotFoundError, sync %s first before %s", parent, sync[changed].path)
         ents = self.state.lookup_path(changed, parent)
         if not ents:
             info = self.providers[changed].info_path(parent)
@@ -729,7 +729,7 @@ class SyncManager(Runnable):
             log.debug("parent=%s", parent_ent)
             if not parent_ent[changed].changed or not parent_ent.is_creation(changed):
                 if sync.priority <= 2:  # punt if not already punted, meaning, punt at least once
-                    log.debug("Provider %s parent folder %s reported missing. punting", self.providers[synced].name, parent)
+                    log.info("Provider %s parent folder %s reported missing. punting", self.providers[synced].name, parent)
                     return PUNT
                 if parent_ent[changed].exists == EXISTS:
                     # this condition indicates the provider has said the parent folder
@@ -743,7 +743,7 @@ class SyncManager(Runnable):
                     parent_info = self.providers[synced].info_oid(parent_ent[synced].oid)
                     sync_parent = self.translate(synced, parent)
                     if parent_info and parent_info.path == sync_parent:
-                        log.debug("Provider %s parent folder %s misreported missing, but parent folder exists. "
+                        log.info("Provider %s parent folder %s misreported missing, but parent folder exists. "
                                   "punting", self.providers[synced].name, parent)
                     else:
                         # oddly, everything we know about the file is that it exists, but
@@ -755,7 +755,7 @@ class SyncManager(Runnable):
                         parent_ent[synced].exists = MISSING
                         assert parent_ent.is_creation(changed), "%s is not a creation" % parent_ent
                         assert parent_ent[changed].needs_sync(), "%s doesn't need sync" % parent_ent
-                        log.debug("updated entry as missing %s", parent_ent)
+                        log.info("updated entry as missing %s", parent_ent)
 
         log.debug("CloudFileNotFoundError, punt")
         return PUNT
@@ -876,8 +876,8 @@ class SyncManager(Runnable):
 
         defer_ent[ent2.side].sync_hash = ent2.sync_hash
         defer_ent[ent2.side].sync_path = ent2.sync_path
-        log.debug("keep ent %s", defer_ent)
-        log.debug("discard ent %s", replace_ent)
+        log.info("keep ent %s", defer_ent)
+        log.info("discard ent %s", replace_ent)
         replace_ent.ignore(IgnoreReason.DISCARDED)
 
     def resolve_conflict(self, side_states):  # pylint: disable=too-many-statements, too-many-branches, too-many-locals
@@ -886,8 +886,8 @@ class SyncManager(Runnable):
             keep: bool
             fh, keep = self.__safe_call_resolver(fhs)
 
-            log.debug("keeping ret side %s", getattr(fh, "side", None))
-            log.debug("fhs[0].side=%s", fhs[0].side)
+            log.info("keeping ret side %s", getattr(fh, "side", None))
+            log.info("fhs[0].side=%s", fhs[0].side)
 
             defer = None
 
@@ -899,9 +899,9 @@ class SyncManager(Runnable):
                     winner = side_states[1 - i]
 
                     # user didn't opt to keep my rfh
-                    log.debug("replacing side %s", loser.side)
+                    log.info("replacing side %s", loser.side)
                     if not keep:
-                        log.debug("not keeping side %s, simply uploading to replace with new contents", loser.side)
+                        log.info("not keeping side %s, simply uploading to replace with new contents", loser.side)
                         fh.seek(0)
                         info2 = self.providers[loser.side].upload(loser.oid, cast(BinaryIO, fh))
                         loser.hash = info2.hash
@@ -911,11 +911,11 @@ class SyncManager(Runnable):
                         if not loser.sync_path:
                             loser.sync_path = loser.path
                     else:
-                        log.debug("rename side %s to conflicted", loser.side)
+                        log.info("rename side %s to conflicted", loser.side)
                         try:
                             self._resolve_rename(loser)
                         except ex.CloudFileNotFoundError:
-                            log.debug("there is no conflict, because the file doesn't exist? %s", loser)
+                            log.warning("there is no conflict, because the file doesn't exist? %s", loser)
 
                     if defer is None:  # the first time we see an rfh to replace, defer gets set to the winner side
                         defer = winner.side
@@ -935,9 +935,9 @@ class SyncManager(Runnable):
                     defer_ent[defer].sync_path = None
                     defer_ent[defer].sync_hash = None
                 else:
-                    log.debug("defer not none, and not keeping, so merge sides")
+                    log.info("defer not none, and not keeping, so merge sides")
                     replace_ent[defer] = defer_ent[defer]
-                    log.debug("discard ent %s", defer_ent)
+                    log.info("discard ent %s", defer_ent)
                     defer_ent.ignore(IgnoreReason.DISCARDED)
                     replace_ent[replace_side].sync_path = replace_ent[replace_side].path
                     replace_ent[replace_side].sync_hash = replace_ent[replace_side].hash
@@ -947,10 +947,10 @@ class SyncManager(Runnable):
                         log.warning("sync path irrelevant during merge")
             else:
                 # both sides were modified, because the fh returned was some third thing that should replace both
-                log.debug("resolver merge upload to both sides: %s", keep)
+                log.info("resolver merge upload to both sides: %s", keep)
                 self.__resolver_merge_upload(side_states, fh, keep)
 
-            log.debug("RESOLVED CONFLICT: %s side: %s", side_states, defer)
+            log.info("RESOLVED CONFLICT: %s side: %s", side_states, defer)
 
     def delete_synced(self, sync, changed, synced):
         log.debug("try sync deleted %s", sync[changed].path)
@@ -960,7 +960,7 @@ class SyncManager(Runnable):
 
         for ent in ents:
             if ent.is_creation(synced):
-                log.debug("discard delete, pending create %s:%s", synced, ent)
+                log.info("discard delete, pending create %s:%s", synced, ent)
                 sync.ignore(IgnoreReason.DISCARDED)
                 return FINISHED
 
@@ -973,7 +973,7 @@ class SyncManager(Runnable):
                 ents = [ent for ent in ents if ent != sync]
                 for ent in ents:
                     if ent.is_rename(synced):
-                        log.debug("discard delete, pending rename %s:%s", synced, ent)
+                        log.info("discard delete, pending rename %s:%s", synced, ent)
                         sync.ignore(IgnoreReason.DISCARDED)
                         return FINISHED
 
@@ -986,11 +986,11 @@ class SyncManager(Runnable):
             except ex.CloudFileExistsError:
                 return self._handle_dir_delete_not_empty(sync, changed, synced)
         else:
-            log.debug("was never synced, ignoring deletion")
+            log.info("was never synced, ignoring deletion")
 
         sync[synced].exists = TRASHED
         if not sync.is_conflicted:
-            log.debug("mark entry discarded %s", sync)
+            log.info("mark entry discarded %s", sync)
             sync.ignore(IgnoreReason.DISCARDED, previous_reasons=IgnoreReason.IRRELEVANT)
         return FINISHED
 
@@ -1017,11 +1017,11 @@ class SyncManager(Runnable):
                     return PUNT
                 return FINISHED
             else:
-                log.debug("all children not fully synced, punt %s", sync[changed].path)
+                log.info("all children not fully synced, punt %s", sync[changed].path)
                 return PUNT
 
         # Mark children changed so we will check if already deleted
-        log.debug("kids exist, mark changed and punt %s", sync[changed].path)
+        log.info("kids exist, mark changed and punt %s", sync[changed].path)
         for kid, _ in self.state.get_kids(sync[changed].path, changed):
             kid[changed].changed = time.time()
 
@@ -1064,7 +1064,7 @@ class SyncManager(Runnable):
         if not other_untrashed_ents:
             return False
 
-        log.debug("split conflict found : %s:%s", len(other_untrashed_ents), other_untrashed_ents)
+        log.info("split conflict found : %s:%s", len(other_untrashed_ents), other_untrashed_ents)
 
         found = None
         info = self.providers[synced].info_path(translated_path)
@@ -1078,7 +1078,7 @@ class SyncManager(Runnable):
                     if e[synced].sync_hash != e[synced].hash:
                         found = e
                     elif not e[synced].changed:
-                        log.debug("merge split entries")
+                        log.info("merge split entries")
                         sync[synced] = e[synced]
                     elif e[synced].otype == DIRECTORY and sync[synced].otype == FILE:
                         # fixes test_cs_folder_conflicts_file
@@ -1090,7 +1090,7 @@ class SyncManager(Runnable):
                         found = False
 
         if not found:
-            log.debug("disjoint conflict with something I don't understand")
+            log.info("disjoint conflict with something I don't understand")
             return True
 
         self.handle_split_conflict(
@@ -1105,7 +1105,7 @@ class SyncManager(Runnable):
             self.update_sync_path(sync, changed)
             log.debug("NEW SYNC %s", sync)
             if sync[changed].exists == TRASHED or sync.is_discarded:
-                log.debug("requeue trashed event %s", sync)
+                log.info("requeue trashed event %s", sync)
                 return PUNT
 
         translated_path = self.translate(synced, sync[changed].path)
@@ -1114,12 +1114,12 @@ class SyncManager(Runnable):
             return FINISHED
 
         if not sync[changed].path:
-            log.debug("can't sync, no path %s", sync)
+            log.warning("can't sync, no path %s", sync)
 
         if sync[changed].sync_path and sync[synced].exists == TRASHED:
             # see test: test_sync_folder_conflicts_del
             if sync.priority <= 0:
-                log.debug("requeue sync + trash priority=%s %s", sync.priority, sync)
+                log.info("requeue sync + trash priority=%s %s", sync.priority, sync)
                 return PUNT
 
             folder_child_conflict = False
@@ -1127,7 +1127,7 @@ class SyncManager(Runnable):
                 kids = self._get_child_conflict(sync, changed)
                 if kids:
                     folder_child_conflict = True
-                    log.debug("folder child conflict found: %s", kids)
+                    log.info("folder child conflict found: %s", kids)
 
             if sync[synced].changed and not folder_child_conflict:        # rename + delete == delete goes first
                 # this is only needed when shuffling
@@ -1141,7 +1141,7 @@ class SyncManager(Runnable):
 
                 if sync[changed].sync_hash == sync[changed].hash:
                     sync[changed].changed = sync[synced].changed + .01
-                    log.debug("reprioritize sync + trash %s  (%s, %s)", sync, sync[changed].changed, sync[synced].changed)
+                    log.info("reprioritize sync + trash %s  (%s, %s)", sync, sync[changed].changed, sync[synced].changed)
                     return PUNT
 
             # folder event getting here implies that there is a child conflict, so create is appropriate
@@ -1149,14 +1149,14 @@ class SyncManager(Runnable):
             log.debug("cleared trashed info, converting to create %s", sync)
 
         if sync.is_creation(changed) and sync.priority == 0 and sync[synced].exists == MISSING:
-            log.debug("create on top of missing, punt, maybe a rename")
+            log.info("create on top of missing, punt, maybe a rename")
             return PUNT
 
         if sync.is_creation(changed):
             # never synced this before, maybe there's another local path with
             # the same name already?
             if self.check_disjoint_create(sync, changed, synced, translated_path):
-                log.debug("disjoint, requeue")
+                log.info("disjoint, requeue")
                 return PUNT
 
         if sync.is_creation(changed):
@@ -1194,10 +1194,10 @@ class SyncManager(Runnable):
         try:
             new_oid = self.providers[synced].rename(sync[synced].oid, translated_path)
         except ex.CloudFileNotFoundError as e:
-            log.debug("ERROR: can't rename for now %s: %s", sync, repr(e))
+            log.error("ERROR: can't rename for now %s: %s", sync, repr(e))
             return self.handle_cloud_file_not_found_error(changed, sync, synced)
         except ex.CloudFileExistsError:
-            log.debug("can't rename, file exists")
+            log.warning("can't rename, file exists")
             if sync.priority <= 0:
                 sync.get_latest(force=True)
             else:
@@ -1211,7 +1211,7 @@ class SyncManager(Runnable):
                         # file is up to date, we're replacing a known synced copy
                         try:
                             self.providers[synced].delete(conflict[synced].oid)
-                            log.debug("deleting %s out of the way", translated_path)
+                            log.info("deleting %s out of the way", translated_path)
                             conflict[synced].exists = TRASHED
                             if not conflict[changed].oid:
                                 # conflict row was because of a rename on-to-of
@@ -1304,11 +1304,11 @@ class SyncManager(Runnable):
                 conflict_path = self.providers[side].join(folder, conflict_name)
                 new_oid = self.providers[side].rename(oinfo.oid, conflict_path)
             except ex.CloudFileExistsError:
-                log.debug("already exists %s", conflict_name)
+                log.info("already exists %s", conflict_name)
                 i = i + 1
                 conflict_name = base + ".conflicted" + str(i) + ext
 
-        log.debug("conflict renamed: %s -> %s", path, conflict_path)
+        log.info("conflict renamed: %s -> %s", path, conflict_path)
         return oinfo.oid, new_oid, conflict_path
 
     def embrace_change(self, sync, changed, synced):  # pylint: disable=too-many-return-statements, too-many-branches
@@ -1316,10 +1316,10 @@ class SyncManager(Runnable):
             translated_path = self.translate(synced, sync[changed].path)
             if not translated_path:
                 if sync[changed].sync_path:  # This entry was relevent, but now it is irrelevant
-                    log.debug(">>>Removing remnants of file moved out of cloud root")
+                    log.info(">>>Removing remnants of file moved out of cloud root")
                     sync[changed].exists = TRASHED  # This will discard the ent later
                 else:  # we don't have a new or old translated path... just irrelevant so discard
-                    log.log(TRACE, ">>>Not a cloud path %s, ignoring", sync[changed].path)
+                    log.info(">>>Not a cloud path %s, ignoring", sync[changed].path)
                     sync.ignore(IgnoreReason.IRRELEVANT)
 
         if sync.is_discarded:
@@ -1329,7 +1329,7 @@ class SyncManager(Runnable):
         log.debug("embrace %s, side:%s", sync, changed)
 
         if sync.is_conflicted:
-            log.debug("Conflicted file %s is changing", sync[changed].path)
+            log.info("Conflicted file %s is changing", sync[changed].path)
             if "conflicted" in sync[changed].path:
                 return FINISHED
             else:
@@ -1355,7 +1355,7 @@ class SyncManager(Runnable):
                     sync.priority = min_priority + 0.1
                     conflict.priority = min_priority
 
-                log.debug("parent modify %s should happen first %s", sync[changed].path, conflict)
+                log.info("parent modify %s should happen first %s", sync[changed].path, conflict)
                 if sync.is_path_change(changed) and sync[synced].exists == TRASHED and sync.priority > 2:
                     # right hand side was trashed at the same time as a rename happened
                     # punting is in a loop
@@ -1392,7 +1392,7 @@ class SyncManager(Runnable):
         return FINISHED
 
     def handle_changed_is_missing(self, sync, changed, synced):     # pylint: disable=no-self-use
-        log.debug("%s missing", sync[changed].path)
+        log.info("%s missing", sync[changed].path)
 
         if sync[synced].exists == EXISTS:
             if sync.priority <= 4:
@@ -1445,7 +1445,7 @@ class SyncManager(Runnable):
 
         info = self.providers[changed].info_oid(sync[changed].oid)
         if not info:
-            log.debug("marking missing %s", debug_sig(sync[changed].oid))
+            log.info("marking missing %s", debug_sig(sync[changed].oid))
             sync[changed].exists = MISSING
             return
 

--- a/cloudsync/tests/test_sync.py
+++ b/cloudsync/tests/test_sync.py
@@ -11,7 +11,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 from cloudsync.tests.fixtures import WaitFor, RunUntilHelper
-from cloudsync import SyncManager, SyncState, CloudFileNotFoundError, CloudFileNameError,\
+from cloudsync import SyncManager, SyncState, CloudFileExistsError, CloudFileNotFoundError, CloudFileNameError,\
         LOCAL, REMOTE, FILE, DIRECTORY, Event, CloudTemporaryError, Notification,\
         NotificationManager, NotificationType
 from cloudsync.runnable import _BackoffError
@@ -1542,6 +1542,38 @@ def test_sync_change_count(sync, unverif):
         assert sync.change_count(unverified=unverif) == 2
     else:
         assert sync.change_count(unverified=unverif) == 1
+
+def test_create_file_exists_to_name_error(sync):
+    (local, remote) = sync.providers
+
+    local_parent = "/local"
+    local_file1 = "/local/file"
+    remote_file1 = "/remote/file"
+
+    sync.providers[LOCAL].mkdir(local_parent)
+    linfo1 = sync.providers[LOCAL].create(local_file1, BytesIO(b"hello"))
+
+    sync.create_event(LOCAL, FILE, path=local_file1, oid=linfo1.oid, hash=linfo1.hash)
+
+    _create = sync.providers[REMOTE].create
+    called = False
+
+    def _called(sync, synced, translated_path):
+        nonlocal called
+        called = True
+
+    # Create throws CloudFileExistsError even though directory doesn't exist
+    def _create_w_error(name, data):
+        nonlocal called, remote_file1
+        if name == remote_file1:
+            raise CloudFileExistsError("File exists error")
+        return _create(name, data)
+
+    # Ensure this situation is handled as a file name error
+    sync.handle_file_name_error = _called
+
+    with patch.object(sync.providers[REMOTE], "create", new=_create_w_error):
+        sync.run(until=lambda: called, timeout=3)
 
 
 # TODO: test to confirm that a sync with an updated path name that is different but matches the old name will be ignored (eg: a/b -> a\b)


### PR DESCRIPTION
Bump one-off log lines. Don't bump regularly occurring log lines higher than debug.

Three areas that should be logged: 1) Cloudsync errors raised 2) conflict resolution 3) punts