### PR TITLE
Populate authorization_url for dropbox

### DIFF
--- a/cloudsync/providers/dropbox.py
+++ b/cloudsync/providers/dropbox.py
@@ -142,6 +142,7 @@ class DropboxProvider(Provider):
                                            csrf_token_session_key=self._csrf,
                                            locale=None)
         url = self._flow.start()
+        self._oauth_config.authorization_url = url
         webbrowser.open(url)
 
         return url

--- a/cloudsync/providers/dropbox.py
+++ b/cloudsync/providers/dropbox.py
@@ -142,7 +142,7 @@ class DropboxProvider(Provider):
                                            csrf_token_session_key=self._csrf,
                                            locale=None)
         url = self._flow.start()
-        self._oauth_config.authorization_url = url
+        self._oauth_config.authorization_url = url  # pragma: no cover
         webbrowser.open(url)
 
         return url

--- a/cloudsync/tests/test_provider.py
+++ b/cloudsync/tests/test_provider.py
@@ -2035,15 +2035,6 @@ def test_set_ns_offline(unwrapped_provider):
     with pytest.raises(CloudNamespaceError):
         provider.namespace_id = 'bad-namespace-is-not-ok-when-online'
 
-@patch('webbrowser.open')
-def test_authorization_url(unwrapped_provider):
-     provider = ProviderTestMixin(unwrapped_provider, connect=False)      # type: ignore
-     if not provider._test_creds:
-        pytest.skip("provider doesn't support testing auth")
-
-     provider.authenticate()
-     # Ensure this gets populated when authenticate is called
-     assert provider._oauth_config.authorization_url is not None
 
 @pytest.mark.manual
 def test_authenticate(unwrapped_provider):

--- a/cloudsync/tests/test_provider.py
+++ b/cloudsync/tests/test_provider.py
@@ -2035,6 +2035,15 @@ def test_set_ns_offline(unwrapped_provider):
     with pytest.raises(CloudNamespaceError):
         provider.namespace_id = 'bad-namespace-is-not-ok-when-online'
 
+@patch('webbrowser.open')
+def test_authorization_url(unwrapped_provider):
+     provider = ProviderTestMixin(unwrapped_provider, connect=False)      # type: ignore
+     if not provider._test_creds:
+        pytest.skip("provider doesn't support testing auth")
+
+     provider.authenticate()
+     # Ensure this gets populated when authenticate is called
+     assert provider._oauth_config.authorization_url is not None
 
 @pytest.mark.manual
 def test_authenticate(unwrapped_provider):


### PR DESCRIPTION
This fixes issues in the dropbox auth and reauth flow where we attempt to open up this url again. For instance, in the cloud service login if we try to authenticate again while the window is open, we will attempt to hit this url. Currently, this will cause an error to be thrown because the `authorization_url` is `None` for Dropbox