### PR TITLE
BI2-1507: Don't wait for long_poll to finish

### DIFF
--- a/cloudsync/cs.py
+++ b/cloudsync/cs.py
@@ -252,7 +252,7 @@ class CloudSync(Runnable):
         self.nmgr.notify(Notification(SourceEnum.SYNC, NotificationType.STARTED, None))
         self.nmgr.start(**kwargs)
 
-    def stop(self, forever=True):
+    def stop(self, forever=True, wait=True):
         """
         Stops the cloudsync service.
 
@@ -260,10 +260,10 @@ class CloudSync(Runnable):
             forever: If false is passed, then handles are left open for a future start.  Generally used for tests only.
         """
         log.info("stopping sync: %s", self.storage_label())
-        self.smgr.stop(forever=forever)
-        self.emgrs[0].stop(forever=forever)
-        self.emgrs[1].stop(forever=forever)
-        self.nmgr.stop(forever=forever)
+        self.smgr.stop(forever=forever, wait=wait)
+        self.emgrs[0].stop(forever=forever, wait=wait)
+        self.emgrs[1].stop(forever=forever, wait=wait)
+        self.nmgr.stop(forever=forever, wait=wait)
         if self.sthread:
             self.sthread.join()
             self.ethreads[0].join()

--- a/cloudsync/long_poll.py
+++ b/cloudsync/long_poll.py
@@ -93,6 +93,6 @@ class LongPollManager(Runnable):
                 log.exception('Unhandled exception during long poll %s', e)
                 Runnable.backoff()
 
-    def stop(self):
-        # Could be stuck waiting for up to long_poll_timeout seconds
-        super().stop(wait=False)
+    def stop(self, forever=True, wait=False):
+        # Don't wait for do() to finish, could wait for up to long_poll_timeout seconds
+        super().stop(forever=forever, wait=wait)

--- a/cloudsync/long_poll.py
+++ b/cloudsync/long_poll.py
@@ -92,3 +92,7 @@ class LongPollManager(Runnable):
                     self.last_set = time.monotonic()
                 log.exception('Unhandled exception during long poll %s', e)
                 Runnable.backoff()
+
+    def stop(self):
+        # Could be stuck waiting for up to long_poll_timeout seconds
+        super().stop(wait=False)

--- a/cloudsync/notification.py
+++ b/cloudsync/notification.py
@@ -86,7 +86,7 @@ class NotificationManager(Runnable):
         """Add notification to the queue"""
         self.__queue.put(e)
 
-    def stop(self, forever=True):
+    def stop(self, forever=True, wait=True):
         """Stop the server"""
         self.__queue.put(None)
-        super().stop(forever=forever)
+        super().stop(forever=forever, wait=wait)

--- a/cloudsync/runnable.py
+++ b/cloudsync/runnable.py
@@ -174,7 +174,7 @@ class Runnable(ABC):
         """
         ...
 
-    def stop(self, forever=True):
+    def stop(self, forever=True, wait=True):
         """
         Stop the service, allowing any do() to complete first.
         """
@@ -183,7 +183,8 @@ class Runnable(ABC):
         self.__shutdown = forever
         if self.__thread:
             if threading.current_thread() != self.__thread:
-                self.wait()
+                if wait:
+                    self.wait()
                 self.__thread = None
 
     def done(self):

--- a/cloudsync/tests/test_runnable.py
+++ b/cloudsync/tests/test_runnable.py
@@ -69,6 +69,27 @@ def test_timeout():
     with pytest.raises(TimeoutError):
         testrun.wait(timeout=.01)
 
+def test_no_wait_stop():
+    class TestRun(Runnable):
+        def __init__(self):
+            self.cleaned = False
+            self.called = 0
+
+        def do(self):
+            time.sleep(10)
+            self.called += 1
+
+        def done(self):
+            self.cleaned = True
+
+    testrun = TestRun()
+    testrun.start()
+    while not testrun.started:
+        time.sleep(.01)
+
+    assert testrun.called == 0
+    testrun.stop(wait=False)
+    assert testrun.called == 0
 
 def test_runnable_wake():
     class TestRun(Runnable):


### PR DESCRIPTION
This will allow us to immediately exit when trying to stop the LongPollManager as opposed to waiting for up to 2 minutes.