### PR TITLE
Fix the [all] extra's dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ jobs:
     - name: lint
       stage: lint/unit
       script:
-        - make -j3 lint
+        - make -j4 lint
     - name: unit
       script:
         - pytest --durations=1 --cov=cloudsync --cov-report=xml -n=2 cloudsync/tests cloudsync/oauth/apiserver.py --timeout=300

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ requirements: env
 	. env/$(ENVBIN)/activate && pip install -r requirements-dev.txt
 	. env/$(ENVBIN)/activate && pip install -r requirements.txt
 
-lint: lint-pylint lint-mypy lint-md
+lint: lint-pylint lint-mypy lint-md lint-deps
 
 lint-pylint:
 	pylint cloudsync --enable=duplicate-code --ignore tests
@@ -26,6 +26,9 @@ lint-mypy:
 
 lint-md: ./node_modules/.bin/remark
 	./node_modules/.bin/remark -f docs/*.md *.md
+
+lint-deps:
+	python check-deps.py
 
 test: test-py test-doc
 
@@ -53,4 +56,4 @@ bumpver:
 ./node_modules/.bin/remark:
 	npm install
 
-.PHONY: test test-py test-doc lint format bumpver env requirements coverage lint-md
+.PHONY: test test-py test-doc lint format bumpver env requirements coverage lint-md lint-deps

--- a/check-deps.py
+++ b/check-deps.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+from typing import List, Set, Any, Optional, Tuple
+import sys
+import toml
+from pprint import pprint
+
+def _find_difference(left: Set[Any], right: Set[Any]) -> Optional[Tuple[Set[Any], Set[Any]]]:
+    left_only = left - right
+    right_only = right - left
+
+    if left_only or right_only:
+        return left_only, right_only
+
+    return None
+
+
+def main() -> int:
+    with open("pyproject.toml") as f:
+        data = toml.load(f)
+
+    requires_extra = data["tool"]["flit"]["metadata"]["requires-extra"]
+
+    deps = set()
+
+    for k, v in requires_extra.items():
+        if k == "all":
+            continue
+
+        deps.update(v)
+
+    extra_all_deps = set(requires_extra["all"])
+
+    diff = _find_difference(deps, extra_all_deps)
+    if diff:
+        extras_only, all_only = diff
+        print("Mismatched dependencies between individual extras and cloudsync[all]")
+        print("Individual features require:", deps)
+        print("[all] requires:", extra_all_deps)
+        print()
+
+        print("Missing from [all]:", extras_only)
+        print("Only in [all]", all_only)
+
+        return 1
+
+    return 0
+
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dropbox = [ "dropbox>=10.3.0", "six>=1.14.0"]
 boxcom = [ "boxsdk[jwt]", ]
 onedrive = [ "cloudsync-onedrive~=2.0.1", ]
 gdrive = [ "cloudsync-gdrive", ]
-all = [ "cloudsync-gdrive", "cloudsync-onedrive", "boxsdk[jwt]", "dropbox", "boxsdk" ]
+all = [ "cloudsync-gdrive", "cloudsync-onedrive~=2.0.1", "boxsdk[jwt]", "dropbox>=10.3.0", "six>=1.14.0", "boxsdk>=2.9.0" ]
 
 [tool.flit.scripts]
 cloudsync = "cloudsync.command:main"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ flaky>=3.6
 coverage
 codecov
 diff-cover
+toml


### PR DESCRIPTION
It's currently possible for the dependencies of all the individual extras to become out of sync with those of the `all` extra. This leads to unexpected behavior, like pulling in an old version of the Dropbox SDK even after a version constraint has been added to `pyproject.toml`.

* ~Fixes some pylint failures that appear to be new with version 2.5.3.~
  * It seems I was mistaken here. The incompatibility was not due to pylint versions, but due to Python versions. The current code passes lint on 3.6, but fails on 3.8. Very strange.
* Adds a script and lint rule that ensure that `all` is in sync with the other extras.
  * This grabs them using the [`toml`](https://pypi.org/project/toml/) package, and essentially does a set comparison of the strings. This ensures that version constraints are in sync. There is, however, some weirdness in that the `boxsdk` package is specified twice, with different constraints.
* Fixes the extras' dependencies to be in sync.