### PR TITLE
fix for sync loop on non empty folder move

### DIFF
--- a/cloudsync/tests/fixtures/mock_provider.py
+++ b/cloudsync/tests/fixtures/mock_provider.py
@@ -430,7 +430,8 @@ class MockProvider(Provider):
         if self.oid_is_path:
             source_object.oid = destination_path
         self._store_object(source_object)
-        self._register_event(MockEvent.ACTION_RENAME, source_object, prior_oid)
+        if event:
+            self._register_event(MockEvent.ACTION_RENAME, source_object, prior_oid)
         log.debug("rename complete %s", source_object.path)
         self._log_debug_state("_rename_single_object")
 

--- a/cloudsync/tests/test_cs.py
+++ b/cloudsync/tests/test_cs.py
@@ -732,6 +732,27 @@ def test_cs_basic(cs):
     assert len(cs.state) == 3
     assert not cs.state.changeset_len
 
+def test_cs_rename_folder_out_of_root(cs):
+    lp = cs.providers[LOCAL]
+    rp = cs.providers[REMOTE]
+
+    rp.mkdir("/remote")
+    rp.mkdir("/outside-root")
+    lp.mkdir("/local")
+    lp.mkdir("/local/stuff1")
+    lp.create("/local/stuff1/file1", BytesIO(b"file1"))
+    #cs.run_until_clean(timeout=1)
+    cs.run(until=lambda: not cs.state.changeset_len, timeout=1)
+    rinfo_stuff1 = rp.info_path("/remote/stuff1")
+    assert rinfo_stuff1
+    log.info("TABLE 1\n%s", cs.state.pretty_print())
+
+    rp.rename(rinfo_stuff1.oid, "/outside-root/stuff2")
+    log.info("TABLE 2\n%s", cs.state.pretty_print())
+
+    #cs.run_until_clean(timeout=1)
+    cs.run(until=lambda: not cs.state.changeset_len, timeout=1)
+    log.info("TABLE 3\n%s", cs.state.pretty_print())
 
 def setup_remote_local(cs, *names, content=b'hello'):
     remote_parent = "/remote"

--- a/cloudsync/tests/test_cs.py
+++ b/cloudsync/tests/test_cs.py
@@ -745,12 +745,13 @@ def test_cs_rename_folder_out_of_root(cs):
 
     cs.run(until=lambda: not cs.state.changeset_len, timeout=1)
     rinfo_stuff1 = rp.info_path("/remote/stuff1")
-    assert rinfo_stuff1
     log.info("TABLE 1\n%s", cs.state.pretty_print())
+    assert rinfo_stuff1
 
     rp.rename(rinfo_stuff1.oid, "/outside-root/stuff2")
     cs.run(until=lambda: not cs.state.changeset_len, timeout=1)
     log.info("TABLE 2\n%s", cs.state.pretty_print())
+    assert not lp.info_path("/local/stuff1")
 
 def setup_remote_local(cs, *names, content=b'hello'):
     remote_parent = "/remote"

--- a/cloudsync/tests/test_cs.py
+++ b/cloudsync/tests/test_cs.py
@@ -736,23 +736,21 @@ def test_cs_rename_folder_out_of_root(cs):
     lp = cs.providers[LOCAL]
     rp = cs.providers[REMOTE]
 
+    # roots are /local, /remote
     rp.mkdir("/remote")
     rp.mkdir("/outside-root")
     lp.mkdir("/local")
     lp.mkdir("/local/stuff1")
     lp.create("/local/stuff1/file1", BytesIO(b"file1"))
-    #cs.run_until_clean(timeout=1)
+
     cs.run(until=lambda: not cs.state.changeset_len, timeout=1)
     rinfo_stuff1 = rp.info_path("/remote/stuff1")
     assert rinfo_stuff1
     log.info("TABLE 1\n%s", cs.state.pretty_print())
 
     rp.rename(rinfo_stuff1.oid, "/outside-root/stuff2")
-    log.info("TABLE 2\n%s", cs.state.pretty_print())
-
-    #cs.run_until_clean(timeout=1)
     cs.run(until=lambda: not cs.state.changeset_len, timeout=1)
-    log.info("TABLE 3\n%s", cs.state.pretty_print())
+    log.info("TABLE 2\n%s", cs.state.pretty_print())
 
 def setup_remote_local(cs, *names, content=b'hello'):
     remote_parent = "/remote"


### PR DESCRIPTION
also set limit on number of punts for the "Attempt dropping dir removal because children appear fully synced" codepath