### PR TITLE
Give providers access to sync state interface

### DIFF
--- a/cloudsync/event.py
+++ b/cloudsync/event.py
@@ -59,6 +59,7 @@ class EventManager(Runnable):
 
         self._provider_guard.add(provider)
         self.provider = provider
+        self.provider.sync_state = state.get_state_lookup(side)
 
         self.label: str = f"{self.provider.name}:{self.provider.connection_id}:{self.provider.namespace_id}"
         self.state: 'SyncState' = state

--- a/cloudsync/provider.py
+++ b/cloudsync/provider.py
@@ -8,13 +8,16 @@ import logging
 import random
 import time
 from dataclasses import dataclass
-from typing import Generator, Optional, List, Union, Tuple, Dict, BinaryIO
+from typing import TYPE_CHECKING, Generator, Optional, List, Union, Tuple, Dict, BinaryIO
 
 from .types import OInfo, DIRECTORY, DirInfo, Any
 from .exceptions import CloudFileNotFoundError, CloudFileExistsError, CloudTokenError, CloudNamespaceError, \
     CloudRootMissingError
 from .oauth import OAuthConfig, OAuthProviderInfo
 from .event import Event
+
+if TYPE_CHECKING:
+    from .sync.state import SyncStateLookup
 
 log = logging.getLogger(__name__)
 
@@ -95,6 +98,8 @@ class Provider(ABC):                    # pylint: disable=too-many-public-method
     connection_id: Optional[str] = None       ; """Must remain constant between logins and must be unique to the login"""
     _creds: Optional[Any] = None              ; """Base class helpers to store creds"""
     __connected = False                       ; """Base class helper to fake a connection"""
+
+    sync_state: 'SyncStateLookup' = None      ; """Used for provider-specific event filtering"""
     # pylint: enable=multiple-statements
 
     @abstractmethod

--- a/cloudsync/provider.py
+++ b/cloudsync/provider.py
@@ -17,7 +17,7 @@ from .oauth import OAuthConfig, OAuthProviderInfo
 from .event import Event
 
 if TYPE_CHECKING:
-    from .sync.state import SyncStateLookup
+    from .sync.state import SyncStateLookup   # pragma: no cover
 
 log = logging.getLogger(__name__)
 

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-__all__ = ['SyncState', 'SyncEntry', 'Storage', 'FILE', 'DIRECTORY', 'UNKNOWN']
+__all__ = ['SyncState', 'SyncStateLookup', 'SyncEntry', 'Storage', 'FILE', 'DIRECTORY', 'UNKNOWN']
 
 # safe ternary, don't allow traditional comparisons
 
@@ -1256,3 +1256,20 @@ class SyncState:  # pylint: disable=too-many-instance-attributes, too-many-publi
             ent[i].path = info.path
             if ent.ignored == IgnoreReason.NONE and not ent[i].changed:
                 ent[i].changed = time.time()
+
+    def get_state_lookup(self, side: int) -> 'SyncStateLookup':
+        return SyncStateLookup(self, side)
+
+
+class SyncStateLookup:
+    """
+    Limited read-only SyncState interface
+    """
+
+    def __init__(self, state: 'SyncState', side: int):
+        self.__state = state
+        self.__side = side
+
+    def get_path(self, oid: str) -> Optional[str]:
+        state = self.__state.lookup_oid(self.__side, oid)
+        return state[self.__side].path if state else None

--- a/cloudsync/tests/test_cs.py
+++ b/cloudsync/tests/test_cs.py
@@ -60,7 +60,7 @@ def make_cs(mock_provider_creator, left=(True, True), right=(True, True), storag
                 name="cs_root_oid")
 def fixture_cs_root_oid(request, mock_provider_generator, mock_provider_creator):
     p1 = mock_provider_generator()
-    p2 = mock_provider_creator(oid_is_path=False, case_sensitive=True, events_have_path=request.param)
+    p2 = mock_provider_creator(oid_is_path=False, case_sensitive=True, filter_events=request.param)
     o1 = p1.mkdir(roots[0])
     o2 = p2.mkdir(roots[1])
     cs = CloudSyncMixin((p1, p2), root_oids=(o1, o2), storage=None, sleep=None)
@@ -735,9 +735,9 @@ def test_cs_basic(cs):
 
 def test_cs_move_in_and_out_of_root(cs):
     # TODO: fix this - moving things in/out of root is not fully supported with event filtering turned off
-    cs.providers[0]._events_have_path = True
-    cs.providers[1]._events_have_path = True
-    log.info("set events_have_path=True for all providers")
+    cs.providers[0]._filter_events = True
+    cs.providers[1]._filter_events = True
+    log.info("set _filter_events=True for all providers")
 
     # roots are set when cs is created: /local, /remote
     lp = cs.providers[LOCAL]


### PR DESCRIPTION
To be used for provider-specific event filtering.

Also considered passing the state interface as a parameter to provider.events() -- a bit cleaner, but this would be a breaking change.