### PR TITLE
Improve prior ent handling when syncing a rename

### DIFF
--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -1015,7 +1015,13 @@ class SyncState:  # pylint: disable=too-many-instance-attributes, too-many-publi
 
             if prior_ent and not prior_ent.is_discarded:
                 if not ent or (not ent.is_conflicted and (prior_ent[side].sync_hash or not ent[side].sync_hash)):
-                    # reuse prior_ent
+                    # if we don't have an ent, reuse the prior_ent
+                    # otherwise, only consider reusing the prior_ent if it has been synced,
+                    #   or if the ent hasn't been synced. if the prior_ent (in a rename this is the "rename from")
+                    #   is a short-lived temp file, and the ent (the "rename to") is a long-lived file that is being
+                    #   replaced as a result of the rename (as often happens when saving in msoffice), then don't use
+                    #   the prior_ent for this reason: the ent has a hash, and the prior_ent doesn't, which can lead
+                    #   to unexpected conflicts arising when resolvable or merge-able changes exist in the cloud
                     _copy = None
                     if ent:
                         # copy information about the other side

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -1014,28 +1014,20 @@ class SyncState:  # pylint: disable=too-many-instance-attributes, too-many-publi
                 ent.ignored = IgnoreReason.NONE
 
             if prior_ent and not prior_ent.is_discarded:
-                if not ent or not ent.is_conflicted:
-                    if not ent or prior_ent[side].sync_hash or not ent[side].sync_hash:
-                        # reuse prior_ent
-                        _copy = None
-                        if ent:
-                            # copy information about the other side
-                            if ent[1-side].oid:
-                                _copy = ent[1-side]
-                        ent = prior_ent
-                        if _copy and not ent[1-side].oid:
-                            log.debug("ent was abandoned with copy")
-                            ent[1-side] = _copy
-                        else:
-                            log.debug("ent was abandoned without copy")
+                if not ent or not ent.is_conflicted \
+                        and (not ent or prior_ent[side].sync_hash or not ent[side].sync_hash):
+                    # reuse prior_ent
+                    _copy = None
+                    if ent:
+                        # copy information about the other side
+                        if ent[1-side].oid:
+                            _copy = ent[1-side]
+                    ent = prior_ent
+                    if _copy and not ent[1-side].oid:
+                        log.debug("ent was abandoned with copy")
+                        ent[1-side] = _copy
                     else:
-                        log.debug("skipped using prior ent because no sync hash side=%s", side)
-                        log.debug("prior ent hash=%s/%s ent hash=%s/%s",
-                                  prior_ent[side].hash, prior_ent[side].sync_hash, ent[side].hash, ent[side].sync_hash)
-                        log.debug("      ent=%s", ent)
-                        log.debug("prior ent=%s", prior_ent)
-                        log.debug("ent=%s, pes.sh=%s, es.sh=%s", bool(ent), bool(prior_ent[side].sync_hash),
-                                  bool(ent[side].sync_hash))
+                        log.debug("ent was abandoned without copy")
             elif not ent:
                 path_ents = self.lookup_path(side, path, stale=True)
                 for path_ent in path_ents:

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -1014,19 +1014,22 @@ class SyncState:  # pylint: disable=too-many-instance-attributes, too-many-publi
                 ent.ignored = IgnoreReason.NONE
 
             if prior_ent and not prior_ent.is_discarded:
-                if (not ent or not ent.is_conflicted) and prior_ent[side].sync_hash and not ent[side].sync_hash:
-                    # reuse prior_ent
-                    _copy = None
-                    if ent:
-                        # copy information about the other side
-                        if ent[1-side].oid:
-                            _copy = ent[1-side]
-                    ent = prior_ent
-                    if _copy and not ent[1-side].oid:
-                        log.debug("ent was abandoned with copy")
-                        ent[1-side] = _copy
+                if not ent or not ent.is_conflicted:
+                    if prior_ent[side].sync_hash and not ent[side].sync_hash:
+                        # reuse prior_ent
+                        _copy = None
+                        if ent:
+                            # copy information about the other side
+                            if ent[1-side].oid:
+                                _copy = ent[1-side]
+                        ent = prior_ent
+                        if _copy and not ent[1-side].oid:
+                            log.debug("ent was abandoned with copy")
+                            ent[1-side] = _copy
+                        else:
+                            log.debug("ent was abandoned without copy")
                     else:
-                        log.debug("ent was abandoned without copy")
+                        log.debug("skipped using prior ent because no sync hash")
             elif not ent:
                 path_ents = self.lookup_path(side, path, stale=True)
                 for path_ent in path_ents:

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -1015,7 +1015,7 @@ class SyncState:  # pylint: disable=too-many-instance-attributes, too-many-publi
 
             if prior_ent and not prior_ent.is_discarded:
                 if not ent or not ent.is_conflicted:
-                    if not ent or prior_ent[side].sync_hash:
+                    if not ent or prior_ent[side].sync_hash or not ent[side].sync_hash:
                         # reuse prior_ent
                         _copy = None
                         if ent:

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -1015,7 +1015,7 @@ class SyncState:  # pylint: disable=too-many-instance-attributes, too-many-publi
 
             if prior_ent and not prior_ent.is_discarded:
                 if not ent or not ent.is_conflicted:
-                    if not ent or (prior_ent[side].sync_hash and not ent[side].sync_hash):
+                    if not ent or prior_ent[side].sync_hash:
                         # reuse prior_ent
                         _copy = None
                         if ent:

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -1015,7 +1015,7 @@ class SyncState:  # pylint: disable=too-many-instance-attributes, too-many-publi
 
             if prior_ent and not prior_ent.is_discarded:
                 if not ent or not ent.is_conflicted \
-                        and (not ent or prior_ent[side].sync_hash or not ent[side].sync_hash):
+                        and (prior_ent[side].sync_hash or not ent[side].sync_hash):
                     # reuse prior_ent
                     _copy = None
                     if ent:

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -1029,7 +1029,9 @@ class SyncState:  # pylint: disable=too-many-instance-attributes, too-many-publi
                         else:
                             log.debug("ent was abandoned without copy")
                     else:
-                        log.debug("skipped using prior ent because no sync hash")
+                        log.debug("skipped using prior ent because no sync hash side=%s", side)
+                        log.debug("prior ent hash=%s/%s ent hash=%s/%s",
+                                  prior_ent[side].hash, prior_ent[side].sync_hash, ent[side].hash, ent[side].sync_hash)
                         log.debug("      ent=%s", ent)
                         log.debug("prior ent=%s", prior_ent)
             elif not ent:

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -1034,6 +1034,8 @@ class SyncState:  # pylint: disable=too-many-instance-attributes, too-many-publi
                                   prior_ent[side].hash, prior_ent[side].sync_hash, ent[side].hash, ent[side].sync_hash)
                         log.debug("      ent=%s", ent)
                         log.debug("prior ent=%s", prior_ent)
+                        log.debug("ent=%s, pes.sh=%s, es.sh=%s", bool(ent), bool(prior_ent[side].sync_hash),
+                                  bool(ent[side].sync_hash))
             elif not ent:
                 path_ents = self.lookup_path(side, path, stale=True)
                 for path_ent in path_ents:

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -1014,8 +1014,7 @@ class SyncState:  # pylint: disable=too-many-instance-attributes, too-many-publi
                 ent.ignored = IgnoreReason.NONE
 
             if prior_ent and not prior_ent.is_discarded:
-                if not ent or not ent.is_conflicted \
-                        and (prior_ent[side].sync_hash or not ent[side].sync_hash):
+                if not ent or (not ent.is_conflicted and (prior_ent[side].sync_hash or not ent[side].sync_hash)):
                     # reuse prior_ent
                     _copy = None
                     if ent:

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -1030,6 +1030,8 @@ class SyncState:  # pylint: disable=too-many-instance-attributes, too-many-publi
                             log.debug("ent was abandoned without copy")
                     else:
                         log.debug("skipped using prior ent because no sync hash")
+                        log.debug("      ent=%s", ent)
+                        log.debug("prior ent=%s", prior_ent)
             elif not ent:
                 path_ents = self.lookup_path(side, path, stale=True)
                 for path_ent in path_ents:

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -1023,7 +1023,7 @@ class SyncState:  # pylint: disable=too-many-instance-attributes, too-many-publi
                             _copy = ent[1-side]
                     ent = prior_ent
                     if _copy and not ent[1-side].oid:
-                        log.debug("ent was abandoned with copy", stack_info=True);
+                        log.debug("ent was abandoned with copy")
                         ent[1-side] = _copy
                     else:
                         log.debug("ent was abandoned without copy")

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -1014,7 +1014,7 @@ class SyncState:  # pylint: disable=too-many-instance-attributes, too-many-publi
                 ent.ignored = IgnoreReason.NONE
 
             if prior_ent and not prior_ent.is_discarded:
-                if not ent or not ent.is_conflicted:
+                if (not ent or not ent.is_conflicted) and prior_ent[side].sync_hash and not ent[side].sync_hash:
                     # reuse prior_ent
                     _copy = None
                     if ent:
@@ -1023,7 +1023,7 @@ class SyncState:  # pylint: disable=too-many-instance-attributes, too-many-publi
                             _copy = ent[1-side]
                     ent = prior_ent
                     if _copy and not ent[1-side].oid:
-                        log.debug("ent was abandoned with copy")
+                        log.debug("ent was abandoned with copy", stack_info=True);
                         ent[1-side] = _copy
                     else:
                         log.debug("ent was abandoned without copy")

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -1015,7 +1015,7 @@ class SyncState:  # pylint: disable=too-many-instance-attributes, too-many-publi
 
             if prior_ent and not prior_ent.is_discarded:
                 if not ent or not ent.is_conflicted:
-                    if prior_ent[side].sync_hash and not ent[side].sync_hash:
+                    if not ent or (prior_ent[side].sync_hash and not ent[side].sync_hash):
                         # reuse prior_ent
                         _copy = None
                         if ent:


### PR DESCRIPTION
Usually, when a file is renamed from a to b, it is advantageous to move the sync information from the (older) "a" sync entry to the (newer) "b" sync entry. In certain cases, notably office applications, "a" is the new file and "b" is a pre-existing file with sync information that needs to be retained. This change will prevent a prior_ent with less sync information from being used, when the primary ent has more sync information already.