### PR TITLE
gdrive-1.0.6 and exists=None fix + test

### DIFF
--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -886,12 +886,12 @@ class SyncState:  # pylint: disable=too-many-instance-attributes, too-many-publi
         if hash is not None and hash != ent[side].hash:
             ent[side].hash = hash
 
-        if exists is not None and exists is not ent[side].exists:
-            if ent[side].exists is TRASHED and exists:
-                # oid was deleted, and then re-created, this can only happen for oid-is-path providers
-                # we mark it as LIKELY_TRASHED, to protect against out-of-order events
-                # see: https://vidaid.atlassian.net/browse/VFM-7246
-                exists = LIKELY_TRASHED
+        if ent[side].exists is TRASHED and exists is True:
+            # oid was deleted, and then re-created, this can only happen for oid-is-path providers
+            # we mark it as LIKELY_TRASHED, to protect against out-of-order events
+            # see: https://vidaid.atlassian.net/browse/VFM-7246
+            ent[side].exists = LIKELY_TRASHED
+        else:
             ent[side].exists = exists
 
         if changed:
@@ -1048,8 +1048,6 @@ class SyncState:  # pylint: disable=too-many-instance-attributes, too-many-publi
             log.debug("creating new entry because %s not found in %s", debug_sig(oid), side)
             ent = SyncEntry(self, otype)
 
-        if exists is None:
-            exists = Exists.UNKNOWN
         self.update_entry(ent, side, oid, path=path, hash=hash, exists=exists, changed=time.time(), otype=otype, accurate=accurate)
 
 

--- a/cloudsync/tests/test_sync.py
+++ b/cloudsync/tests/test_sync.py
@@ -1616,5 +1616,24 @@ def test_hash_diff_file_name_error(sync):
     assert check.getvalue() == b"hello"
     assert sync.state.lookup_oid(LOCAL, info2.oid).ignored == IgnoreReason.IRRELEVANT
 
+def test_exists_none(sync):
+    (local, remote) = sync.providers
+
+    local_parent = "/local"
+    local_file = "/local/file"
+    local_dir = "/local/dir"
+    remote_file = "/remote/file"
+    remote_dir = "/remote/dir"
+
+    local.mkdir(local_parent)
+    info = local.create(local_file, BytesIO(b"hello"))
+
+    sync.create_event(LOCAL, FILE, path=local_file, oid=info.oid, hash=info.hash, exists=None)
+    sync.run(until=lambda: remote.exists_path(remote_file), timeout=2)
+
+    dir_oid = local.mkdir(local_dir)
+
+    sync.create_event(LOCAL, DIRECTORY, path=local_dir, oid=dir_oid, exists=None)
+    sync.run(until=lambda: remote.exists_path(remote_dir), timeout=2)
 
 # TODO: test to confirm that a sync with an updated path name that is different but matches the old name will be ignored (eg: a/b -> a\b)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ box = [ "boxsdk>=2.9.0", ]
 dropbox = [ "dropbox>=10.3.0", "six>=1.14.0"]
 boxcom = [ "boxsdk[jwt]", ]
 onedrive = [ "cloudsync-onedrive>=2.1.0", ]
-gdrive = [ "cloudsync-gdrive>=1.0.5", ]
-all = [ "cloudsync-gdrive>=1.0.5", "cloudsync-onedrive>=2.1.0", "boxsdk[jwt]", "dropbox>=10.3.0", "six>=1.14.0", "boxsdk>=2.9.0" ]
+gdrive = [ "cloudsync-gdrive>=1.0.6", ]
+all = [ "cloudsync-gdrive>=1.0.6", "cloudsync-onedrive>=2.1.0", "boxsdk[jwt]", "dropbox>=10.3.0", "six>=1.14.0", "boxsdk>=2.9.0" ]
 
 [tool.flit.scripts]
 cloudsync = "cloudsync.command:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ boxsdk[jwt]>=2.9.0
 
 # other providers we run tests for
 cloudsync-onedrive>=2.1.0
-cloudsync-gdrive>=1.0.5
+cloudsync-gdrive>=1.0.6
 
 # command line 
 python-daemon


### PR DESCRIPTION
This PR contains the following changes:

1) fixes a bug where the EXISTS enum is used as a bool when exists=None which causes Errors.
2) Bump cloudsync gdrive version
3) Add a test for events with exists=None