### PR TITLE
Don't flush events on test_provider cleanup

### DIFF
--- a/cloudsync/tests/test_provider.py
+++ b/cloudsync/tests/test_provider.py
@@ -344,7 +344,6 @@ class ProviderTestMixin(ProviderBase):
 
         if not self.prov.connected:
             self.prov.connect(self._test_creds)
-        self.prime_events()
         info = self.prov.info_path(self.test_root)
         if info:
             self.__cleanup(info.oid)


### PR DESCRIPTION
This caused 15+ minute teardowns  in test_provider for gdrive and subsequent failure. This seems to fix it