### PR TITLE
Remove CloudNamespaceError

### DIFF
--- a/cloudsync/provider.py
+++ b/cloudsync/provider.py
@@ -11,8 +11,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Generator, Optional, List, Union, Tuple, Dict, BinaryIO
 
 from .types import OInfo, DIRECTORY, DirInfo, Any
-from .exceptions import CloudFileNotFoundError, CloudFileExistsError, CloudTokenError, CloudNamespaceError, \
-    CloudRootMissingError
+from .exceptions import CloudFileNotFoundError, CloudFileExistsError, CloudTokenError, CloudRootMissingError
 from .oauth import OAuthConfig, OAuthProviderInfo
 from .event import Event
 
@@ -365,7 +364,7 @@ class Provider(ABC):                    # pylint: disable=too-many-public-method
 
     @namespace.setter
     def namespace(self, ns: Namespace):                    # pylint: disable=no-self-use
-        raise CloudNamespaceError("This provider does not support namespaces")
+        pass
 
     @property
     def namespace_id(self) -> Optional[str]:               # pylint: disable=no-self-use
@@ -377,7 +376,7 @@ class Provider(ABC):                    # pylint: disable=too-many-public-method
 
     @namespace_id.setter
     def namespace_id(self, ns_id: str):                    # pylint: disable=no-self-use
-        raise CloudNamespaceError("This provider does not support namespaces")
+        pass
 
     @classmethod
     def uses_oauth(cls):

--- a/cloudsync/provider.py
+++ b/cloudsync/provider.py
@@ -364,7 +364,7 @@ class Provider(ABC):                    # pylint: disable=too-many-public-method
 
     @namespace.setter
     def namespace(self, ns: Namespace):                    # pylint: disable=no-self-use
-        pass
+        pass   # pragma: no cover
 
     @property
     def namespace_id(self) -> Optional[str]:               # pylint: disable=no-self-use
@@ -376,7 +376,8 @@ class Provider(ABC):                    # pylint: disable=too-many-public-method
 
     @namespace_id.setter
     def namespace_id(self, ns_id: str):                    # pylint: disable=no-self-use
-        pass
+        pass   # pragma: no cover
+
 
     @classmethod
     def uses_oauth(cls):

--- a/cloudsync/tests/test_provider.py
+++ b/cloudsync/tests/test_provider.py
@@ -624,6 +624,8 @@ def test_namespace(provider):
     if not ns:
         assert not provider.namespace_id
         assert not provider.namespace
+        provider.namespace_id = "id"
+        provider.namespace = Namespace("name", "space")
         return
 
     saved = provider.namespace_id

--- a/cloudsync/tests/test_provider.py
+++ b/cloudsync/tests/test_provider.py
@@ -624,8 +624,6 @@ def test_namespace(provider):
     if not ns:
         assert not provider.namespace_id
         assert not provider.namespace
-        provider.namespace_id = "id"
-        provider.namespace = Namespace("name", "space")
         return
 
     saved = provider.namespace_id

--- a/cloudsync/tests/test_provider.py
+++ b/cloudsync/tests/test_provider.py
@@ -37,7 +37,7 @@ import cloudsync
 import cloudsync.providers
 
 from cloudsync import Event, CloudException, CloudFileNotFoundError, CloudDisconnectedError, CloudTemporaryError, CloudFileExistsError, \
-        CloudOutOfSpaceError, CloudCursorError, CloudTokenError, CloudNamespaceError
+        CloudOutOfSpaceError, CloudCursorError, CloudTokenError
 from cloudsync.provider import Namespace
 from cloudsync.tests.fixtures import Provider, MockProvider
 from cloudsync.runnable import time_helper
@@ -624,10 +624,6 @@ def test_namespace(provider):
     if not ns:
         assert not provider.namespace_id
         assert not provider.namespace
-        with pytest.raises(CloudNamespaceError):
-            provider.namespace_id = "id"
-        with pytest.raises(CloudNamespaceError):
-            provider.namespace = Namespace("name", "space")
         return
 
     saved = provider.namespace_id
@@ -2034,12 +2030,7 @@ def test_set_ns_offline(unwrapped_provider):
 
     provider.namespace_id = 'bad-namespace-is-ok-at-least-when-offline'
     log.info("ns id %s", provider.namespace_id)
-    with pytest.raises(CloudNamespaceError):
-        provider.connect(provider._test_creds)
     assert provider.namespace is None  # setting a bad ns id makes this None
-    with pytest.raises(CloudNamespaceError):
-        provider.namespace_id = 'bad-namespace-is-not-ok-when-online'
-
 
 @pytest.mark.manual
 def test_authenticate(unwrapped_provider):


### PR DESCRIPTION
This has caused problems in CryptVFS. I don't think raising an error here buys us much. Open to discussing the pros and cons of keeping this in vs. taking it out.