### PR TITLE
BI2-1811: Fix slow activation when re-adding a bed via config

### DIFF
--- a/cloudsync/cs.py
+++ b/cloudsync/cs.py
@@ -94,13 +94,16 @@ class CloudSync(Runnable):
         self.test_mgr_iter = None
         self.test_mgr_order: List[int] = []
 
-    def forget(self):
+    def forget(self, roots: Optional[Tuple[str, str]] = None):
         """
-        Forget and discard state information, and drop any events in the queue.  This will trigger a walk.
+        Forget and discard state information, and drop any events in the queue.  
+        This will trigger a walk if root_path is not None or the emgr root is set.
         """
+        event_root_paths: Tuple[Optional[str], Optional[str]] = roots or (None, None)
+
         self.state.forget()
-        self.emgrs[0].forget()
-        self.emgrs[1].forget()
+        self.emgrs[0].forget(event_root_paths[0])
+        self.emgrs[1].forget(event_root_paths[1])
 
     @property
     def aging(self) -> float:

--- a/cloudsync/cs.py
+++ b/cloudsync/cs.py
@@ -94,16 +94,13 @@ class CloudSync(Runnable):
         self.test_mgr_iter = None
         self.test_mgr_order: List[int] = []
 
-    def forget(self, roots: Optional[Tuple[str, str]] = None):
+    def forget(self):
         """
-        Forget and discard state information, and drop any events in the queue.  
-        This will trigger a walk if root_path is not None or the emgr root is set.
+        Forget and discard state information, and drop any events in the queue.  This will trigger a walk.
         """
-        event_root_paths: Tuple[Optional[str], Optional[str]] = roots or (None, None)
-
         self.state.forget()
-        self.emgrs[0].forget(event_root_paths[0])
-        self.emgrs[1].forget(event_root_paths[1])
+        self.emgrs[0].forget()
+        self.emgrs[1].forget()
 
     @property
     def aging(self) -> float:

--- a/cloudsync/event.py
+++ b/cloudsync/event.py
@@ -111,14 +111,14 @@ class EventManager(Runnable):
         if self._walk_tag is not None:
             self.state.storage_delete_tag(self._walk_tag)
         elif self._root_path is not None:
-            self.state.storage_delete_tag(self.label + "_walked_" + self.root_path)
+            self.state.storage_delete_tag(self.label + "_walked_" + self._root_path)
         else:
             log.warning("Not deleting walk tag for %s", self.label)
 
         if self._cursor_tag is not None:
             self.state.storage_delete_tag(self._cursor_tag)
         elif self._root_path is not None:
-            self.state.storage_delete_tag(self.label + "_cursor_" + self.root_path)
+            self.state.storage_delete_tag(self.label + "_cursor_" + self._root_path)
         else:
             log.warning("Not deleting cursor tag for %s", self.label)
 

--- a/cloudsync/event.py
+++ b/cloudsync/event.py
@@ -104,21 +104,20 @@ class EventManager(Runnable):
     def __reauth(self):
         self.provider.connect(self.provider.authenticate())
 
-    def forget(self, root_path: Optional[str] = None):
+    def forget(self):
         self._first_do = True
         self.need_walk = True
 
-        
         if self._walk_tag is not None:
             self.state.storage_delete_tag(self._walk_tag)
-        elif root_path is not None:
+        elif self._root_path is not None:
             self.state.storage_delete_tag(self.label + "_walked_" + root_path)
         else:
             log.warning("Not deleting walk tag for %s", self.label)
 
         if self._cursor_tag is not None:
             self.state.storage_delete_tag(self._cursor_tag)
-        elif root_path is not None:
+        elif self._root_path is not None:
             self.state.storage_delete_tag(self.label + "_cursor_" + root_path)
         else:
             log.warning("Not deleting cursor tag for %s", self.label)

--- a/cloudsync/event.py
+++ b/cloudsync/event.py
@@ -111,14 +111,14 @@ class EventManager(Runnable):
         if self._walk_tag is not None:
             self.state.storage_delete_tag(self._walk_tag)
         elif self._root_path is not None:
-            self.state.storage_delete_tag(self.label + "_walked_" + root_path)
+            self.state.storage_delete_tag(self.label + "_walked_" + self.root_path)
         else:
             log.warning("Not deleting walk tag for %s", self.label)
 
         if self._cursor_tag is not None:
             self.state.storage_delete_tag(self._cursor_tag)
         elif self._root_path is not None:
-            self.state.storage_delete_tag(self.label + "_cursor_" + root_path)
+            self.state.storage_delete_tag(self.label + "_cursor_" + self.root_path)
         else:
             log.warning("Not deleting cursor tag for %s", self.label)
 

--- a/cloudsync/event.py
+++ b/cloudsync/event.py
@@ -114,14 +114,14 @@ class EventManager(Runnable):
         elif self._root_path is not None:
             self.state.storage_delete_tag(self.label + "_walked_" + self._root_path)
         else:
-            log.warning("Not deleting walk tag for %s", self.label)
+            log.warning("Not deleting walk tag for %s", self.label)  # pragma: no cover
 
         if self._cursor_tag is not None:
             self.state.storage_delete_tag(self._cursor_tag)
         elif self._root_path is not None:
             self.state.storage_delete_tag(self.label + "_cursor_" + self._root_path)
         else:
-            log.warning("Not deleting cursor tag for %s", self.label)
+            log.warning("Not deleting cursor tag for %s", self.label)  # pragma: no cover
 
     @property
     def busy(self):

--- a/cloudsync/event.py
+++ b/cloudsync/event.py
@@ -105,6 +105,7 @@ class EventManager(Runnable):
         self.provider.connect(self.provider.authenticate())
 
     def forget(self):
+        """Clean up db state. If tags are not populated, build tag with root_path"""
         self._first_do = True
         self.need_walk = True
 

--- a/cloudsync/event.py
+++ b/cloudsync/event.py
@@ -104,14 +104,24 @@ class EventManager(Runnable):
     def __reauth(self):
         self.provider.connect(self.provider.authenticate())
 
-    def forget(self):
+    def forget(self, root_path: Optional[str] = None):
         self._first_do = True
         self.need_walk = True
 
+        
         if self._walk_tag is not None:
             self.state.storage_delete_tag(self._walk_tag)
+        elif root_path is not None:
+            self.state.storage_delete_tag(self.label + "_walked_" + root_path)
+        else:
+            log.warning("Not deleting walk tag for %s", self.label)
+
         if self._cursor_tag is not None:
             self.state.storage_delete_tag(self._cursor_tag)
+        elif root_path is not None:
+            self.state.storage_delete_tag(self.label + "_cursor_" + root_path)
+        else:
+            log.warning("Not deleting cursor tag for %s", self.label)
 
     @property
     def busy(self):

--- a/cloudsync/tests/test_cs.py
+++ b/cloudsync/tests/test_cs.py
@@ -3021,7 +3021,7 @@ def test_walk_tag_delete(mock_provider_generator):
     p2.disconnect()
 
     cs1 = CloudSyncMixin((p1, p2), roots, storage, sleep=None)
-    
+
     # Disconnected remote provider -> can't validate root -> no walk tag
     assert cs1.emgrs[LOCAL]._walk_tag is not None
     assert cs1.emgrs[REMOTE]._walk_tag is None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ box = [ "boxsdk>=2.9.0", ]
 dropbox = [ "dropbox>=10.3.0", "six>=1.14.0"]
 boxcom = [ "boxsdk[jwt]", ]
 onedrive = [ "cloudsync-onedrive>=2.1.0", ]
-gdrive = [ "cloudsync-gdrive>=1.0.8", ]
-all = [ "cloudsync-gdrive>=1.0.8", "cloudsync-onedrive>=2.1.0", "boxsdk[jwt]", "dropbox>=10.3.0", "six>=1.14.0", "boxsdk>=2.9.0" ]
+gdrive = [ "cloudsync-gdrive>=1.0.9", ]
+all = [ "cloudsync-gdrive>=1.0.9", "cloudsync-onedrive>=2.1.0", "boxsdk[jwt]", "dropbox>=10.3.0", "six>=1.14.0", "boxsdk>=2.9.0" ]
 
 [tool.flit.scripts]
 cloudsync = "cloudsync.command:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ boxsdk[jwt]>=2.9.0
 
 # other providers we run tests for
 cloudsync-onedrive>=2.1.0
-cloudsync-gdrive>=1.0.8
+cloudsync-gdrive>=1.0.9
 
 # command line 
 python-daemon


### PR DESCRIPTION
The problem was related to the walk tag not being removed from the db in the event a bed was forgotten but had not been started which is how we remove beds via econfig. The proposed solution is to use the root_path to construct an unvalidated root to build the walk tag to remove from the db if a validated root is not present.

Misc:
Bump gdrive to 1.0.9