### PR TITLE
Clear backoff on successful sync() call

### DIFF
--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -331,7 +331,7 @@ class SyncManager(Runnable):
 
         ordered = sorted((LOCAL, REMOTE), key=lambda e: sync[e].changed or 0)
 
-        something_got_done = False
+        something_got_done = True
 
         for side in ordered:
             if not sync[side].needs_sync():
@@ -383,8 +383,11 @@ class SyncManager(Runnable):
                 something_got_done = True
                 self.finished(side, sync)
             elif response == PUNT:
+                something_got_done = False
                 sync.punt()
-            # otherwise, just do it again, the contract is that returning REQUEUE involved some manual manipulation of the priority
+            else:
+                # otherwise, just do it again, the contract is that returning REQUEUE involved some manual manipulation of the priority
+                something_got_done = False
             break
 
         return something_got_done

--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -322,18 +322,18 @@ class SyncManager(Runnable):
             self.finished(REMOTE, sync)
             return True
 
-        if self.in_backoff and sync.is_latest_side(REMOTE):
+        if self.in_backoff:
             # Sync manager is in backoff (degraded performance) and the following get_latest() call will not make any
-            # REMOTE provider calls -- make a dummy call to ensure we are connected.
+            # provider calls -- make a dummy call to ensure we are connected.
             #
-            # If successful, then it is safe to clear backoff even though this iteration will not do any REMOTE syncing.
+            # If successful, then it is safe to clear backoff even though this iteration will not do any syncing.
             # If it fails then an exception is raised and backoff is increased.
             #
             # The idea is to resolve the degraded performance that comes with operating "in_backoff"
             # as quickly as possible, rather than wait for it to resolve itself naturally.
-            #
-            # TODO: hardcoding REMOTE is a hack, because REMOTE is a cloud provider by convention only
-            self.providers[REMOTE].info_path("/", use_cache=False)
+            for side in [LOCAL, REMOTE]:
+                if sync.is_latest_side(side):
+                    self.providers[side].info_path("/", use_cache=False)
 
         something_got_done = True
         sync.get_latest()

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -573,6 +573,10 @@ class SyncEntry:
                 return False
         return True
 
+    def is_latest_side(self, side: int) -> bool:
+        max_changed = max(self[LOCAL].changed or 0, self[REMOTE].changed or 0)
+        return max_changed <= self[side]._last_gotten
+
     def is_related_to(self, e):
         for side in (LOCAL, REMOTE):
             for attr in ("path", "sync_path"):

--- a/cloudsync/tests/test_sync.py
+++ b/cloudsync/tests/test_sync.py
@@ -1140,16 +1140,16 @@ def test_backoff_cleared_after_disconnect(sync):
     log.warning("TABLE 0:\n%s", sync.state.pretty_print())
 
     with patch.object(sync, "in_backoff", 1):
-        with patch.object(sync.providers[0], "get_quota") as dummy:
+        with patch.object(sync.providers[REMOTE], "info_path") as dummy:
             sync.create_event(LOCAL, FILE, path=local_file, oid=lfil.oid, hash=lfil.hash)
             sync_entry = sync.state.lookup_oid(LOCAL, lfil.oid)
             sync_entry[LOCAL].changed -= 100
             sync.run_until_clean(timeout=1)
             # in backoff, processing a NOOP event - force provider call to ensure connectivity and clear backoff
-            dummy.assert_called_once()
+            dummy.assert_called_once_with("/", use_cache=False)
 
     with patch.object(sync, "in_backoff", 1):
-        with patch.object(sync.providers[0], "get_quota") as dummy:
+        with patch.object(sync.providers[REMOTE], "info_path") as dummy:
             sync.create_event(LOCAL, FILE, path=local_file, oid=lfil.oid, hash=lfil.hash)
             sync.run_until_clean(timeout=1)
             # in backoff, processing an event that "does something" - skip dummy provider calls


### PR DESCRIPTION
As before, do not clear backoff on PUNT and REQUEUE, clear backoff on FINISHED.

The change here is to also clear backoff when `sync()` determines that `embrace_change()` need not be called and completes successfully.