### PR TITLE
reduce log spam from mkdir errors

### DIFF
--- a/cloudsync/event.py
+++ b/cloudsync/event.py
@@ -157,7 +157,8 @@ class EventManager(Runnable):
                 self._do_unsafe()
         except (CloudTemporaryError, CloudDisconnectedError, CloudNamespaceError) as e:
             # CloudRootMissingError is a CloudTemporaryError so handled here
-            log.warning("temporary error %s[%s] in event watcher", type(e), e)
+            if not self.in_backoff:
+                log.warning("temporary error %s[%s] in event watcher", type(e), e)
             if self.__nmgr:
                 self.__nmgr.notify_from_exception(SourceEnum(self.side), e)
             self.backoff()

--- a/cloudsync/provider.py
+++ b/cloudsync/provider.py
@@ -184,7 +184,10 @@ class Provider(ABC):                    # pylint: disable=too-many-public-method
             info = self.info_path(root_path)
             if info and info.otype != DIRECTORY:
                 raise CloudRootMissingError(f"Root path is not a directory: {root_path}")
-            root_oid = info.oid if info else self.mkdirs(root_path)
+            try:
+                root_oid = info.oid if info else self.mkdirs(root_path)
+            except:
+                raise CloudRootMissingError(f"Failed to create root path: {root_path}")
         return (root_path, root_oid)
 
     @property

--- a/cloudsync/tests/test_events.py
+++ b/cloudsync/tests/test_events.py
@@ -195,6 +195,13 @@ def test_event_provider_contract(manager, rootless_manager, mode):
             notify.notify_from_exception.assert_called_once()
             assert not manager._root_validated
 
+    with patch.object(manager, "_validate_root", raise_root_missing_error):
+        with pytest.raises(Exception):
+            # _BackoffError
+            manager.do()
+            notify.notify_from_exception.assert_called_once()
+            assert not manager._root_validated
+
     prov.connection_id = None
     with pytest.raises(ValueError):
         # connection id is required

--- a/cloudsync/tests/test_provider.py
+++ b/cloudsync/tests/test_provider.py
@@ -36,8 +36,19 @@ from _pytest.fixtures import FixtureLookupError
 import cloudsync
 import cloudsync.providers
 
-from cloudsync import Event, CloudException, CloudFileNotFoundError, CloudDisconnectedError, CloudTemporaryError, CloudFileExistsError, \
-        CloudOutOfSpaceError, CloudCursorError, CloudTokenError, CloudNamespaceError
+from cloudsync import (
+    Event,
+    CloudException,
+    CloudFileNotFoundError,
+    CloudDisconnectedError,
+    CloudTemporaryError,
+    CloudFileExistsError,
+    CloudOutOfSpaceError,
+    CloudCursorError,
+    CloudTokenError,
+    CloudNamespaceError,
+    CloudRootMissingError
+)
 from cloudsync.provider import Namespace
 from cloudsync.tests.fixtures import Provider, MockProvider
 from cloudsync.runnable import time_helper
@@ -596,6 +607,11 @@ def test_info_root(provider):
 def test_set_root_path_creates_path(provider):
     # root path does not exist yet
     assert not provider.info_path("/sync_root")
+
+    # failure to create the root dir is a CloudRootMissingError
+    with patch.object(provider.prov, "mkdirs", side_effect=Exception):
+        with pytest.raises(CloudRootMissingError):
+            provider.set_root(root_path="/sync_root")
 
     # set_root creates it
     (root_path, root_oid) = provider.set_root(root_path="/sync_root")


### PR DESCRIPTION
- convert mkdirs errors to CloudRootMissingError in Provider._validate_root()
- don't log repeated CloudTemporaryErrors in EventManager.do()