### PR TITLE
refactor other_side function to OTHER_SIDE tuple

### DIFF
--- a/cloudsync/smartsync.py
+++ b/cloudsync/smartsync.py
@@ -4,7 +4,7 @@ import logging
 from dataclasses import dataclass
 from typing import Optional, Tuple, TYPE_CHECKING, Callable, List, Set, cast, Union
 from cloudsync.sync import MISSING, TRASHED
-from cloudsync import CloudSync, SyncManager, SyncState, SyncEntry, EventManager, Event, other_side
+from cloudsync import CloudSync, SyncManager, SyncState, SyncEntry, EventManager, Event, OTHER_SIDE
 from cloudsync.types import LOCAL, REMOTE, DIRECTORY, OInfo, DirInfo
 import cloudsync.exceptions as ex
 from cloudsync.tests.fixtures import RunUntilHelper
@@ -464,10 +464,10 @@ class SmartCloudSync(CloudSync):
         # oid MUST exist on the specified side
         #   then, if target exists on same side, renaming on that side will fail in the rename
         #   check if target exists only on the other side, and raise the FileExists here if so
-        other = other_side(side)
+        other = OTHER_SIDE[side]
         other_side_new_path = self.translate(other, new_path)
         if self.providers[other].exists_path(other_side_new_path):
-            other_side_adverb = "remotely" if other_side == REMOTE else "locally"
+            other_side_adverb = "remotely" if other == REMOTE else "locally"
             raise ex.CloudFileExistsError("Rename target %s already exists %s as %s" % (new_path, other_side_adverb, other_side_new_path))
         return self.providers[side].rename(oid, new_path)
 

--- a/cloudsync/sync/__init__.py
+++ b/cloudsync/sync/__init__.py
@@ -1,5 +1,5 @@
 __all__ = ['SyncManager', 'SyncState', 'SyncEntry', 'Storage', 'FILE', 'DIRECTORY', 'UNKNOWN', 'SqliteStorage',
-           'MISSING', 'TRASHED', 'EXISTS', 'UNKNOWN', 'LIKELY_TRASHED', 'other_side']
+           'MISSING', 'TRASHED', 'EXISTS', 'UNKNOWN', 'LIKELY_TRASHED', 'OTHER_SIDE']
 
 from .manager import *
 from .state import *

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -34,8 +34,8 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 OTHER_SIDE = (1, 0)
 
-__all__ = ['SyncState', 'SyncStateLookup', 'SyncEntry', 'Storage',
-           'FILE', 'DIRECTORY', 'UNKNOWN', 'MISSING', 'TRASHED', 'EXISTS', 'LIKELY_TRASHED', 'OTHER_SIDE']
+__all__ = ['SyncState', 'SideState', 'SyncStateLookup', 'SyncEntry', 'Storage',
+           'FILE', 'DIRECTORY', 'UNKNOWN', 'MISSING', 'TRASHED', 'EXISTS', 'LIKELY_TRASHED', 'OTHER_SIDE', 'CORRUPT']
 # safe ternary, don't allow traditional comparisons
 
 

--- a/cloudsync/tests/test_sync.py
+++ b/cloudsync/tests/test_sync.py
@@ -18,7 +18,7 @@ from cloudsync import SyncManager, SyncState, CloudFileExistsError, CloudFileNot
 from cloudsync.runnable import _BackoffError
 from cloudsync.provider import Provider
 from cloudsync.types import OInfo, IgnoreReason
-from cloudsync.sync.state import TRASHED, MISSING, SideState, other_side
+from cloudsync.sync.state import TRASHED, MISSING, SideState, OTHER_SIDE
 
 log = logging.getLogger(__name__)
 
@@ -333,7 +333,7 @@ def test_create_before_delete(sync, delete_side):
     l, r = sync.providers
     delete, create = (l, r) if delete_side == LOCAL else (r, l)
     delete_parent, create_parent = ("/local", "/remote") if delete_side == LOCAL else ("/remote", "/local")
-    create_side = other_side(delete_side)
+    create_side = OTHER_SIDE[delete_side]
     create_path = create.join(create_parent, "hello")
     create_path2 = create.join(create_parent, "goodbye")
     delete_path = delete.join(delete_parent, "hello")
@@ -379,7 +379,7 @@ def test_delete_plus_unchanged_marked_changed(sync, delete_side):
     l, r = sync.providers
     delete, create = (l, r) if delete_side == LOCAL else (r, l)
     delete_parent, create_parent = ("/local", "/remote") if delete_side == LOCAL else ("/remote", "/local")
-    create_side = other_side(delete_side)
+    create_side = OTHER_SIDE[delete_side]
     create_path = create.join(create_parent, "goodbye")
     delete_path = delete.join(delete_parent, "goodbye")
 

--- a/cloudsync/tests/test_sync.py
+++ b/cloudsync/tests/test_sync.py
@@ -18,7 +18,7 @@ from cloudsync import SyncManager, SyncState, CloudFileExistsError, CloudFileNot
 from cloudsync.runnable import _BackoffError
 from cloudsync.provider import Provider
 from cloudsync.types import OInfo, IgnoreReason
-from cloudsync.sync.state import TRASHED, MISSING, SideState, OTHER_SIDE
+from cloudsync.sync.state import TRASHED, MISSING, SideState, OTHER_SIDE, UNKNOWN, EXISTS
 
 log = logging.getLogger(__name__)
 
@@ -259,6 +259,48 @@ def test_sync_hash(sync):
     sync.providers[REMOTE].download(info.oid, check)
 
     assert check.getvalue() == b"hello2"
+    sync.state.assert_index_is_correct()
+
+
+def test_sync_no_info(sync):
+    remote_parent = "/remote"
+    local_parent = "/local"
+    local_path1 = "/local/stuff1"
+    remote_path1 = "/remote/stuff1"
+
+    sync.providers[LOCAL].mkdir(local_parent)
+    sync.providers[REMOTE].mkdir(remote_parent)
+    linfo = sync.providers[LOCAL].create(local_path1, BytesIO(b"hello"))
+
+    old_info_oid = sync.providers[LOCAL].info_oid
+
+    def new_info_oid(oid: str, use_cache=True):
+        info = old_info_oid(oid, use_cache)
+        if oid != linfo.oid:
+            return info
+        info.hash = None
+        return info
+
+    with patch.object(sync.providers[LOCAL], "info_oid", side_effect=new_info_oid):
+        with patch.object(sync.providers[LOCAL], "hash_oid", new=lambda _a, use_cache=True: None):
+            sync.create_event(LOCAL, FILE, path=local_path1, oid=linfo.oid, hash=None, exists=EXISTS)
+            ent = sync.state.lookup_oid(LOCAL, linfo.oid)
+            sync.run(until=lambda: not ent[LOCAL].changed)
+
+    assert sync.providers[LOCAL].exists_path(local_path1)
+    assert not sync.providers[REMOTE].exists_path(remote_path1)
+
+    sync.providers[LOCAL].delete(linfo.oid)
+
+    # with patch.object(sync.providers[LOCAL], "info_oid", new=lambda _a, use_cache: None):
+    sync.create_event(LOCAL, FILE, path=local_path1, oid=linfo.oid, hash=None, exists=UNKNOWN)
+    ent = sync.state.lookup_oid(LOCAL, linfo.oid)
+    sync.run(until=lambda: not ent[LOCAL].changed)
+
+    assert not sync.providers[LOCAL].exists_path(local_path1) # never actually deleted, provider lied and said it was trashed
+    assert not sync.providers[REMOTE].exists_path(remote_path1)
+
+
     sync.state.assert_index_is_correct()
 
 


### PR DESCRIPTION
avoids the overhead of a function call, 
replaces an all-lowercase global function name (which competes in the global namespace with variable names) with an all-uppercase global tuple,
fixes an example of using `other_side` as a variable by mistake, because it LOOKS like a variable, so of course this was bound to happen