### PR TITLE
Fix long_poller thread running beyond the end of the tests

### DIFF
--- a/cloudsync/provider.py
+++ b/cloudsync/provider.py
@@ -180,7 +180,7 @@ class Provider(ABC):                    # pylint: disable=too-many-public-method
                 raise CloudRootMissingError(f"Root path is not a directory: {root_path}")
             try:
                 root_oid = info.oid if info else self.mkdirs(root_path)
-            except:
+            except Exception:
                 raise CloudRootMissingError(f"Failed to create root path: {root_path}")
 
         self._root_path = root_path

--- a/cloudsync/runnable.py
+++ b/cloudsync/runnable.py
@@ -11,6 +11,7 @@ from abc import ABC, abstractmethod
 
 import threading
 import logging
+from typing import Optional
 log = logging.getLogger(__name__)
 
 
@@ -46,13 +47,17 @@ class Runnable(ABC):
     service_name = None                         ; """The name of this runnable service, defaults to the class name"""
     # pylint: enable=multiple-statements
 
-    __thread = None
+    __thread: Optional[threading.Thread] = None
     __shutdown = False
     __interrupt: threading.Event = None
     __stopped = False
     __stopping = False
     __log: logging.Logger = None
     __clear_on_success: bool = True
+
+    @property
+    def _thread(self):
+        return self.__thread
 
     @property
     def stopped(self):
@@ -128,8 +133,6 @@ class Runnable(ABC):
             if self.__shutdown:
                 self.done()
 
-            self.__thread = None
-            log.debug("stopping %s", self.service_name)
 
     @property
     def started(self):
@@ -169,13 +172,20 @@ class Runnable(ABC):
         if self.__shutdown:
             raise RuntimeError("Service was stopped, create a new instance to run.")
         if self.__thread:
-            self.__thread.join(timeout=1)  # give the old thread a chance to die
-        if self.__thread:
-            raise RuntimeError("Service already started")
+            if self.__thread.is_alive():
+                self.__thread.join(timeout=1)  # give the old thread a chance to die
+            if self.__thread.is_alive():
+                raise RuntimeError("Service already started")
         self.__stopping = False
         self.__thread = threading.Thread(target=self.run, kwargs=kwargs, daemon=daemon, name=self.service_name)
         self.__thread.name = self.service_name
         self.__thread.start()
+
+    @property
+    def _thread_id(self):
+        if self.__thread:
+            return self.__thread.ident
+        return None
 
     @abstractmethod
     def do(self):
@@ -195,7 +205,7 @@ class Runnable(ABC):
             if threading.current_thread() != self.__thread:
                 if wait:
                     self.wait()
-                self.__thread = None
+                    self.__thread = None  # if we're not waiting, keep this around so can join() it later
 
     def done(self):
         """


### PR DESCRIPTION
- confirm long_poller has stopped after tests
- manage runnable threads better
- fix wrap_retry in tests when temporary error is expected
- disconnect provider in test cleanup
- disable wrap_retry in tests for provider methods that generators 
