### PR TITLE
block corrupt files when uploading or downloading during sync

### DIFF
--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -1234,7 +1234,8 @@ class SyncManager(Runnable):
                         return FINISHED
                     return PUNT
 
-                log.debug("synced is_corrupt=%s, corrupt_gone=%s, corrupt_exists=%s", sync[synced].is_corrupt, sync[synced].corrupt_gone, sync[synced].corrupt_exists)
+                log.debug("synced is_corrupt=%s, corrupt_gone=%s, corrupt_exists=%s",
+                          sync[synced].is_corrupt, sync[synced].corrupt_gone, sync[synced].corrupt_exists)
                 return self.create_synced(changed, sync, translated_path)
             except ex.CloudCorruptError:
                 # see comment on the SideState.is_corrupt method for more information on the corrupt state

--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -629,8 +629,8 @@ class SyncManager(Runnable):
 
         synced = OTHER_SIDE[changed]
         try:
-            info = self.providers[synced].upload(
-                sync[synced].oid, open(sync[changed].temp_file, "rb"))
+            temp_fh = open(sync[changed].temp_file, "rb")
+            info = self.providers[synced].upload(sync[synced].oid, temp_fh)
             log.debug("upload to %s as path %s",
                       self.providers[synced].name, sync[synced].sync_path)
 
@@ -672,6 +672,9 @@ class SyncManager(Runnable):
             # Nothing else to sync
             self.handle_file_name_error(sync, synced, sync[synced].path)
             return True
+        finally:
+            if temp_fh:
+                temp_fh.close()
 
     def _create_synced(self, changed, sync, translated_path):
         synced = OTHER_SIDE[changed]
@@ -1223,14 +1226,20 @@ class SyncManager(Runnable):
             except ex.CloudCorruptError:
                 # see comment on the SideState.is_corrupt method for more information on the corrupt state
                 log.debug("Handling corrupt download in handle_path_change_or_creation")
-                return self.handle_corrupt_download(changed, sync)
+                return self.handle_corrupt(changed, sync)
 
-            if sync[synced].oid and sync[synced].exists not in (TRASHED, MISSING) and not sync[synced].corrupt_gone:
-                if self.upload_synced(changed, sync):
-                    return FINISHED
-                return PUNT
+            try:
+                if sync[synced].oid and sync[synced].exists not in (TRASHED, MISSING) and not sync[synced].corrupt_gone:
+                    if self.upload_synced(changed, sync):
+                        return FINISHED
+                    return PUNT
 
-            return self.create_synced(changed, sync, translated_path)
+                log.debug("synced is_corrupt=%s, corrupt_gone=%s, corrupt_exists=%s", sync[synced].is_corrupt, sync[synced].corrupt_gone, sync[synced].corrupt_exists)
+                return self.create_synced(changed, sync, translated_path)
+            except ex.CloudCorruptError:
+                # see comment on the SideState.is_corrupt method for more information on the corrupt state
+                log.debug("Handling corrupt upload in handle_path_change_or_creation")
+                return self.handle_corrupt(changed, sync)
 
         if not sync[changed].is_corrupt:
             return self.handle_rename(sync, changed, synced, translated_path)
@@ -1239,7 +1248,7 @@ class SyncManager(Runnable):
             return FINISHED
 
     @staticmethod
-    def handle_corrupt_download(changed, sync: SyncEntry):
+    def handle_corrupt(side, sync: SyncEntry):
         # prevent syncing the current version of the file as it exists on the changed side, as well as any
         # further syncing of deletions or renames on this side. Additionally, mark the other side as unsynced,
         # so the remote file syncs down over the local file.
@@ -1249,13 +1258,12 @@ class SyncManager(Runnable):
         # known good file, and we don't want to sync up these maintenance operations. Once the hash changes
         # on this side, the corrupt flag will be automatically cleared inside the SideState, and then syncing
         # can continue as normal.
-        synced = other_side(changed)
-        sync[changed].sync_hash = sync[changed].hash
-        sync[changed].sync_path = sync[changed].path
-        sync[changed].exists = CORRUPT
+        sync[side].sync_hash = sync[side].hash
+        sync[side].sync_path = sync[side].path
+        sync[side].exists = CORRUPT
 
         # cause the other side to sync down over the corrupt file, if it exists
-        sync[synced].mark_changed()
+        sync[OTHER_SIDE[side]].mark_changed()
         return FINISHED
 
     def handle_rename(self, sync, changed, synced, translated_path):            # pylint: disable=too-many-branches,too-many-statements,too-many-return-statements
@@ -1573,15 +1581,14 @@ class SyncManager(Runnable):
 
         try:
             dc_result = self.download_changed(changed, sync)
+            if not dc_result:
+                return PUNT
+            if not self.upload_synced(changed, sync):
+                return PUNT
         except ex.CloudCorruptError:
             # see comment on the SideState.is_corrupt method for more information on the corrupt state
-            log.debug("Handling corrupt download in handle hash_diff")
-            return self.handle_corrupt_download(changed, sync)
-
-        if not dc_result:
-            return PUNT
-        if not self.upload_synced(changed, sync):
-            return PUNT
+            log.debug("Handling corrupt file in hash_diff")
+            return self.handle_corrupt(changed, sync)
 
         return FINISHED
 

--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -1481,7 +1481,7 @@ class SyncManager(Runnable):
 
             # fall through in case of hash change
 
-        if sync[changed].hash != sync[changed].sync_hash or sync[synced].corrupt_exists:
+        if sync[changed].hash != sync[changed].sync_hash or (sync[synced].is_corrupt and not sync[synced].corrupt_gone):
             return self.handle_hash_diff(sync, changed, synced)
 
         log.debug("nothing changed %s", sync)

--- a/cloudsync/sync/manager.py
+++ b/cloudsync/sync/manager.py
@@ -1222,11 +1222,6 @@ class SyncManager(Runnable):
                 return self.handle_corrupt(changed, sync)
 
             try:
-                if sync[synced].oid and sync[synced].exists not in (TRASHED, MISSING) and not sync[synced].corrupt_gone:
-                    if self.upload_synced(changed, sync):
-                        return FINISHED
-                    return PUNT
-
                 log.debug("synced is_corrupt=%s, corrupt_gone=%s, corrupt_exists=%s",
                           sync[synced].is_corrupt, sync[synced].corrupt_gone, sync[synced].corrupt_exists)
                 return self.create_synced(changed, sync, translated_path)
@@ -1486,7 +1481,7 @@ class SyncManager(Runnable):
 
             # fall through in case of hash change
 
-        if sync[changed].hash != sync[changed].sync_hash:
+        if sync[changed].hash != sync[changed].sync_hash or sync[synced].corrupt_exists:
             return self.handle_hash_diff(sync, changed, synced)
 
         log.debug("nothing changed %s", sync)

--- a/cloudsync/sync/state.py
+++ b/cloudsync/sync/state.py
@@ -445,9 +445,8 @@ class SyncEntry:
     def is_creation(self, side):
         if self[side].path and self[side].exists == EXISTS:
             if self[side].needs_sync():
-                return not self[OTHER_SIDE[side]].oid or self[OTHER_SIDE[side]].exists in (TRASHED, MISSING)
-            else:
-                return self[OTHER_SIDE[side]].is_corrupt
+                return not self[OTHER_SIDE[side]].oid or self[OTHER_SIDE[side]].exists in (TRASHED, MISSING) or \
+                       self[OTHER_SIDE[side]].corrupt_gone
         return False
 
     def is_rename(self, changed):


### PR DESCRIPTION
Previous iteration blocks synchronization of corrupt files that are detected when downloading the file from the changed side. This enhancement blocks synchronization also when uploading the changed file to the synced side.