### PR TITLE
Deflake test_runnable tests

### DIFF
--- a/cloudsync/runnable.py
+++ b/cloudsync/runnable.py
@@ -203,7 +203,7 @@ class Runnable(ABC):
                 if wait:
                     self.wait()
                 if not thread.is_alive:
-                    self.__thread = None
+                    self.__thread = None  # pragma: no cover
 
     def done(self):
         """

--- a/cloudsync/runnable.py
+++ b/cloudsync/runnable.py
@@ -180,10 +180,9 @@ class Runnable(ABC):
         if self.__thread:
             raise RuntimeError("Service already started")
         self.__stopping = False
-        thread = threading.Thread(target=self.run, kwargs=kwargs, daemon=daemon, name=self.service_name)
-        thread.name = self.service_name
-        thread.start()
-        self.__thread = thread
+        self.__thread = threading.Thread(target=self.run, kwargs=kwargs, daemon=daemon, name=self.service_name)
+        self.__thread.name = self.service_name
+        self.__thread.start()
 
     @abstractmethod
     def do(self):

--- a/cloudsync/runnable.py
+++ b/cloudsync/runnable.py
@@ -6,7 +6,6 @@ thread management.
 """
 
 import time
-from contextlib import suppress
 
 from abc import ABC, abstractmethod
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,7 @@ sphinx==2.2.1
 recommonmark==0.6.0
 requests_oauthlib
 python-daemon
+
+
+# docutils 0.18 breaks sphinx
+docutils!=0.18


### PR DESCRIPTION
There were a number of problems that caused the tests in `test_runnable.py` to be flaky.
- When a thread started by a test runs after the test runner has completed running the test, any attempt to log from the thread will result in a `ValueError: I/O operation on closed file`. The runnable tests were starting runnables, but not being careful to stop the runnable thread prior to the end of the test. For whatever reason, suppressing the exception does not prevent the test from failing.
- `Runnable.stop()` had a race condition where it would check if `self.__thread` was not `None` and then use it if so. This variable is changed in other threads, however, so it can be not `None` at the time of the check, but become `None` prior to being dereferenced.
