### PR TITLE
Bugfix: check also module nome cointaing "cloudsync"

### DIFF
--- a/cloudsync/registry.py
+++ b/cloudsync/registry.py
@@ -23,7 +23,7 @@ def discover_providers():
     """Loop through imported modules, and autoregister providers, including plugins"""
     for m in sys.modules:
         mod = sys.modules[m]
-        if hasattr(mod, "__cloudsync__"):
+        if hasattr(mod, "__cloudsync__") and "cloudsync" in mod.__name__:
             if mod.__cloudsync__.name not in providers:             # type: ignore
                 register_provider(mod.__cloudsync__)                # type: ignore
 


### PR DESCRIPTION
Avoid a very weird bug with tensorflow: if tensorflow is imported before cloudsync, the package tensorboard.compat.tensorflow_stub.pywrap_tensorflow will pass the check on hasattr, while in fact it does not have that, causing a type error on the next line